### PR TITLE
Makefile will submodule init if fox is missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,8 +111,10 @@ ${BUILDDIR}/Makefile.inc:
 		fi
 
 # Automatically pull the submodules if the user didn't.
+# Remove the Makefile.QUIP if it has failed previously.
 src/${FOX}/configure:
 	@echo "Attempting to automatically clone fox submodule"
+	rm -f src/${FOX}/Makefile.QUIP
 	git submodule update --init src/${FOX} || \
 	    { echo "fox clone failed. Download it manually" ; exit 1 ; }
 

--- a/Makefile
+++ b/Makefile
@@ -110,8 +110,13 @@ ${BUILDDIR}/Makefile.inc:
 		exit 1 ;\
 		fi
 
+# Automatically pull the submodules if the user didn't.
+src/${FOX}/configure:
+	@echo "Attempting to automatically clone fox submodule"
+	git submodule update --init src/${FOX} || \
+	    { echo "fox clone failed. Download it manually" ; exit 1 ; }
 
-${FOX}: src/${FOX}/objs.${QUIP_ARCH}/lib/libFoX_common.a
+${FOX}: src/${FOX}/configure src/${FOX}/objs.${QUIP_ARCH}/lib/libFoX_common.a
 src/${FOX}/objs.${QUIP_ARCH}/lib/libFoX_common.a:
 	cp Makefile.fox src/${FOX}/Makefile.QUIP
 	make -C src/${FOX} -I${PWD} -I${PWD}/arch -I${BUILDDIR} -f Makefile.QUIP


### PR DESCRIPTION
With this change, running `make` will attempt to run `git submodule update --init src/fox` if it finds that fox is missing. It should be clearer than the current failure mechanism that just says there is a missing file.

I'm putting this as a pull request in case people think that it is too much magic and that we should just issue a warning to run the command manually instead?
