### PR TITLE
Add many-body dispersion to QUIP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ endif
 
 ifeq (${HAVE_MBD},1)
 libmbd.a: libAtoms
-	cp ${PWD}/src/ThirdParty/MBD/Makefile ${BUILDDIR}/Makefile
+	cp ${PWD}/src/ThirdParty/MBD/Makefile.QUIP ${BUILDDIR}/Makefile
 	${MAKE} -C ${BUILDDIR} QUIP_ROOT=${QUIP_ROOT} VPATH=${PWD}/src/ThirdParty/MBD -I${PWD} -I${PWD}/arch $@
 MBD=libmbd.a
 else

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,9 @@ endif
 ifeq (${HAVE_MTP},1)
    THIRDPARTY_LIBS += libmtp.a
 endif
+ifeq (${HAVE_MBD},1)
+   THIRDPARTY_LIBS += mbd_utils.mod
+endif
 endif
 
 MODULES += libAtoms

--- a/Makefile
+++ b/Makefile
@@ -67,12 +67,13 @@ endif
 ifeq (${HAVE_MTP},1)
    THIRDPARTY_LIBS += libmtp.a
 endif
-ifeq (${HAVE_MBD},1)
-   THIRDPARTY_LIBS += libmbd.a # Is this even used?
-endif
 endif
 
 MODULES += libAtoms
+
+ifeq (${HAVE_MBD},1)
+   THIRDPARTY_LIBS += MBD # depends on libAtoms, so can't go through ThirdParty
+endif
 
 # add GAP modules if we have them - they need to come before other modules, except for libAtoms
 ifeq (${HAVE_GAP},1)
@@ -157,7 +158,16 @@ ifeq (${HAVE_GAP_FILLER},1)
 GAP-filler: libAtoms GAP Potentials Utils
 endif
 
-Potentials: libAtoms  ${GAP}
+ifeq (${HAVE_MBD},1)
+libmbd.a: libAtoms
+	cp ${PWD}/src/ThirdParty/MBD/Makefile ${BUILDDIR}/Makefile
+	${MAKE} -C ${BUILDDIR} QUIP_ROOT=${QUIP_ROOT} VPATH=${PWD}/src/ThirdParty/MBD -I${PWD} -I${PWD}/arch $@
+MBD=libmbd.a
+else
+MBD=
+endif
+
+Potentials: libAtoms  ${GAP} ${MBD}
 Utils:  libAtoms ${GAP} Potentials
 FilePot_drivers:  libAtoms  Potentials Utils
 Programs: libAtoms ${GAP} Potentials Utils

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ ifeq (${HAVE_MTP},1)
    THIRDPARTY_LIBS += libmtp.a
 endif
 ifeq (${HAVE_MBD},1)
-   THIRDPARTY_LIBS += mbd_utils.mod
+   THIRDPARTY_LIBS += libmbd.a # Is this even used?
 endif
 endif
 

--- a/Makefile.config
+++ b/Makefile.config
@@ -370,6 +370,22 @@ ifndef HAVE_MTP
 	   fi
 endif
 
+
+ifndef HAVE_MBD
+	@echo "Do you want to compile with many-body dispersion support ? [y/n]"
+	@echo "   Default: n"
+	@read HAVE_MBD && \
+	   if [[ $$HAVE_MBD == 'y' ]]; then \
+	     if [[ ! -d src/ThirdParty/MBD ]] ; then \
+	       echo "MBD sources must be present in the src/ThirdParty directory"; \
+	     else \
+	       echo "HAVE_MBD=1" >> ${BUILDDIR}/Makefile.inc ; \
+	     fi \
+	   else \
+	     echo "HAVE_MBD=0" >> ${BUILDDIR}/Makefile.inc ; \
+	   fi
+endif
+
 ifndef HAVE_LMTO_TBE
 	@echo
 	@echo "Please enter directories where LMTO_TBE libraries are kept:"

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -158,6 +158,10 @@ ifeq (${HAVE_MTP},1)
   DEFINES += -DHAVE_MTP
   SYSLIBS += -lmtp -lstdc++
 endif
+ifeq (${HAVE_MBD},1)
+  DEFINES += -DHAVE_MBD
+  SYSLIBS += -lmbd
+endif
 ifeq (${HAVE_LMTO_TBE},1)
   DEFINES += -DHAVE_LMTO_TBE
   INCLUDES += $(addprefix -I,${LMTO_TBE_LIBDIR}/mods)

--- a/src/Potentials/IP.f95
+++ b/src/Potentials/IP.f95
@@ -60,6 +60,7 @@
 !%    \item    Fourth-order force-constant potential ({\bf IPModel_FC4})
 !%    \item    SCME multipole model for water ({\bf IPModel_SCME})
 !%    \item    MTP potential ({\bf IPModel_MTP})
+!%    \item    Many-body dispersion ({\bf IPModel_MBD})
 !%    \item    ZBL potential ({\bf IPModel_ZBL})
 !%    \item    LinearSOAP potential ({\bf IPModel_LinearSOAP})
 !%    \item    Template potential ({\bf IPModel_Template})
@@ -101,6 +102,7 @@
 !%    \item    'IP FC4'
 !%    \item    'IP SCME'
 !%    \item    'IP MTP'
+!%    \item    'IP MBD'
 !%    \item    'IP ZBL'
 !%    \item    'IP LinearSOAP'
 !%    \item    'IP Template'
@@ -165,6 +167,7 @@ use IPModel_Multipoles_module, only : ipmodel_multipoles, initialise, finalise, 
 use IPModel_FC4_module, only : ipmodel_fc4, initialise, finalise, calc, print
 use IPModel_SCME_module, only : ipmodel_scme, initialise, finalise, calc, print
 use IPModel_MTP_module, only : ipmodel_mtp, initialise, finalise, calc, print
+use IPModel_MBD_module, only : ipmodel_mbd, initialise, finalise, calc, print
 ! Add new IP here
 
 implicit none
@@ -176,7 +179,8 @@ integer, parameter :: FF_LJ = 1, FF_SW = 2, FF_Tersoff = 3, FF_EAM_ErcolAd = 4, 
      FF_Brenner_2002 = 12, FF_ASAP = 13, FF_TS = 14, FF_FC = 15, FF_Morse = 16, FF_GLUE = 17, FF_PartridgeSchwenke = 18, &
      FF_Einstein = 19, FF_Coulomb = 20, FF_Sutton_Chen = 21, FF_KIM = 22, FF_FX = 23, FF_HFdimer = 24, FF_Custom = 25, FF_SW_VP=26, &
      FF_BornMayer = 27, FF_WaterDimer_Gillan=28, FF_WaterTrimer_Gillan=29, FF_Tether=30, FF_LMTO_TBE=31, FF_FC4 = 32, FF_Spring=33, &
-     FF_Multipoles=34, FF_SCME = 35, FF_MTP = 36, FF_ZBL=37, FF_LinearSOAP=38, & ! Add new IPs here
+     FF_Multipoles=34, FF_SCME = 35, FF_MTP = 36, FF_ZBL=37, FF_LinearSOAP=38, &
+     FF_MBD=39, & ! Add new IPs here
      FF_Template = 99
 
 public :: IP_type
@@ -224,6 +228,7 @@ type IP_type
   type(IPModel_SCME) ip_SCME
   type(IPModel_MTP) ip_MTP
   type(IPModel_ZBL) ip_ZBL
+  type(IPModel_MBD) ip_MBD
   type(IPModel_LinearSOAP) ip_LinearSOAP
      ! Add new IP here
   type(IPModel_Template) ip_Template
@@ -334,7 +339,7 @@ subroutine IP_Initialise_str(this, args_str, param_str, mpi_obj, error)
        is_Brenner_Screened, is_Brenner_2002, is_ASAP, is_TS, is_Glue, is_PartridgeSchwenke, is_Einstein, is_Coulomb, &
        is_Sutton_Chen, is_KIM, is_FX, is_HFdimer, is_BornMayer, is_Custom, is_SW_VP, is_WaterDimer_Gillan , &
        is_WaterTrimer_Gillan, is_Tether, is_Spring, is_LMTO_TBE, is_FC4 , is_Multipoles, is_SCME, is_MTP, & 
-       is_ZBL, is_LinearSOAP, &! Add new IPs here
+       is_MBD, is_ZBL, is_LinearSOAP, &! Add new IPs here
        is_Template
 
   INIT_ERROR(error)
@@ -386,6 +391,7 @@ subroutine IP_Initialise_str(this, args_str, param_str, mpi_obj, error)
   call param_register(params, 'FC4', 'false', is_FC4, help_string="Fourth-order force-constant potential of Esfarjani et al")
   call param_register(params, 'SCME', 'false', is_SCME, help_string="SCME water potential")
   call param_register(params, 'MTP', 'false', is_MTP, help_string="MTP potential")
+  call param_register(params, 'MBD', 'false', is_MBD, help_string="Many-body dispersion correction")
   call param_register(params, 'ZBL', 'false', is_ZBL, help_string="ZBL potential")
   call param_register(params, 'LinearSOAP', 'false', is_LinearSOAP, help_string="LinearSOAP potential")
  ! Add new IP here
@@ -399,7 +405,7 @@ subroutine IP_Initialise_str(this, args_str, param_str, mpi_obj, error)
   if (count((/is_GAP, is_LJ, is_FC, is_Morse, is_SW, is_Tersoff, is_EAM_ErcolAd, is_Brenner, is_FS, is_BOP, is_FB, is_Si_MEAM, &
        is_Brenner_Screened, is_Brenner_2002, is_ASAP, is_TS, is_Glue, is_PartridgeSchwenke, is_Einstein, is_Coulomb, &
        is_Sutton_Chen, is_KIM, is_FX, is_HFdimer, is_BornMayer, is_Custom, is_SW_VP, is_WaterDimer_Gillan,is_WaterTrimer_Gillan, &
-       is_Tether, is_Spring, is_LMTO_TBE, is_FC4,  is_Multipoles, is_SCME, is_MTP, is_ZBL,is_linearSOAP, & ! add new IPs here
+       is_Tether, is_Spring, is_LMTO_TBE, is_FC4,  is_Multipoles, is_SCME, is_MTP, is_MBD, is_ZBL,is_linearSOAP, & ! add new IPs here
        is_Template /)) /= 1) then
     RAISE_ERROR("IP_Initialise_str found too few or too many IP Model types args_str='"//trim(args_str)//"'", error)
   endif
@@ -516,6 +522,9 @@ subroutine IP_Initialise_str(this, args_str, param_str, mpi_obj, error)
   else if (is_MTP) then
      this%functional_form = FF_MTP
      call Initialise(this%ip_MTP, args_str, param_str)
+  else if (is_MBD) then
+     this%functional_form = FF_MBD
+     call Initialise(this%ip_MBD, args_str, param_str)
   else if (is_ZBL) then
      this%functional_form = FF_ZBL
      call Initialise(this%ip_ZBL, args_str, param_str)
@@ -613,6 +622,8 @@ subroutine IP_Finalise(this)
       call Finalise(this%ip_SCME)
    case (FF_MTP)
       call Finalise(this%ip_MTP)
+   case (FF_MBD)
+      call Finalise(this%ip_MBD)
    case (FF_ZBL)
       call Finalise(this%ip_ZBL)
    case (FF_LinearSOAP)
@@ -705,6 +716,8 @@ function IP_cutoff(this)
      IP_cutoff = this%ip_SCME%cutoff
   case (FF_MTP)
      IP_cutoff = this%ip_MTP%cutoff
+  case (FF_MBD)
+     IP_cutoff = this%ip_MBD%cutoff
   case (FF_ZBL)
      IP_cutoff = this%ip_ZBL%cutoff
   case (FF_LinearSOAP)
@@ -824,6 +837,8 @@ subroutine IP_Calc(this, at, energy, local_e, f, virial, local_virial, args_str,
       call calc(this%ip_SCME, at, energy, local_e, f, virial, local_virial, args_str, mpi=this%mpi_local, error=error)
    case (FF_MTP)
       call calc(this%ip_MTP, at, energy, local_e, f, virial, local_virial, args_str, mpi=this%mpi_local, error=error)
+   case (FF_MBD)
+      call calc(this%ip_MBD, at, energy, local_e, f, virial, local_virial, args_str, mpi=this%mpi_local, error=error)
    case (FF_ZBL)
       call calc(this%ip_ZBL, at, energy, local_e, f, virial, local_virial, args_str, mpi=this%mpi_local, error=error)
    case (FF_LinearSOAP)
@@ -925,6 +940,8 @@ subroutine IP_Print(this, file, error)
       call Print(this%ip_SCME, file=file)
    case (FF_MTP)
       call Print(this%ip_MTP, file=file)
+   case (FF_MBD)
+      call Print(this%ip_MBD, file=file)
    case (FF_ZBL)
       call Print(this%ip_ZBL, file=file)
    case (FF_LinearSOAP)

--- a/src/Potentials/IPModel_MBD.f95
+++ b/src/Potentials/IPModel_MBD.f95
@@ -40,6 +40,7 @@
 !% TODO the Makefile should automatically patch their UTILS.F90 and compile it
 !%      in
 !%
+!% For more information on the method and parameters see ThirdParty/MBD/README
 !X
 !XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 !XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -224,10 +225,10 @@ subroutine IPModel_MBD_Calc(this, at, e, local_e, f, virial, local_virial, args_
    hirshfeld_volume = my_hirshfeld_volume
 
    call MBD_at_rsSCS(energy)
-#endif
 #ifdef _MPI
    PASS_MPI_ERROR(mpiierror, error)
-#endif
+#endif /*MPI*/
+#endif /*MBD*/
 
 #ifdef HAVE_MBD
    if (present(e)) e = energy * HARTREE

--- a/src/Potentials/Makefile
+++ b/src/Potentials/Makefile
@@ -53,7 +53,7 @@ TB_F77_SOURCES = ${addsuffix .f, ${TB_F77_FILES}}
 TB_F95_SOURCES = ${addsuffix .f95, ${TB_F95_FILES}}
 TB_F95_OBJS = ${addsuffix .o, ${TB_F77_FILES} ${TB_F95_FILES}}
 
-IP_F95_FILES = IPEwald Yukawa Multipoles IPModel_GAP IPModel_LJ IPModel_Morse IPModel_FC IPModel_SW IPModel_Tersoff IPModel_EAM_Ercolessi_Adams IPModel_Brenner IPModel_FS IPModel_BOP IPModel_FB IPModel_Si_MEAM IPModel_Brenner_Screened IPModel_Brenner_2002 IPModel_TS IPModel_Glue IPModel_PartridgeSchwenke IPModel_Einstein IPModel_Coulomb IPModel_Sutton_Chen IPModel_FX IPModel_HFdimer IPModel_BornMayer IPModel_Custom IPModel_Template IPModel_SW_VP IPModel_WaterDimer_Gillan IPModel_WaterTrimer_Gillan IPModel_Tether IPModel_LMTO_TBE IPModel_Multipoles IPModel_FC4 IPModel_Spring IPModel_SCME IPModel_MTP IPModel_ZBL IPModel_LinearSOAP
+IP_F95_FILES = IPEwald Yukawa Multipoles IPModel_GAP IPModel_LJ IPModel_Morse IPModel_FC IPModel_SW IPModel_Tersoff IPModel_EAM_Ercolessi_Adams IPModel_Brenner IPModel_FS IPModel_BOP IPModel_FB IPModel_Si_MEAM IPModel_Brenner_Screened IPModel_Brenner_2002 IPModel_TS IPModel_Glue IPModel_PartridgeSchwenke IPModel_Einstein IPModel_Coulomb IPModel_Sutton_Chen IPModel_FX IPModel_HFdimer IPModel_BornMayer IPModel_Custom IPModel_Template IPModel_SW_VP IPModel_WaterDimer_Gillan IPModel_WaterTrimer_Gillan IPModel_Tether IPModel_LMTO_TBE IPModel_Multipoles IPModel_FC4 IPModel_Spring IPModel_SCME IPModel_MTP IPModel_MBD IPModel_ZBL IPModel_LinearSOAP
 
 ifeq (${HAVE_ASAP},1)
   IP_F95_FILES += IPModel_ASAP


### PR DESCRIPTION
This links in the code from http://www.fhi-berlin.mpg.de/~tkatchen/MBD/ (patched version available in ThirdParty) to add the many-body dispersion energy (with predefined Hirshfeld volumes) as a QUIP potential.