### PR TITLE
Remove farray.__getslice__ and farray.__setslice__

### DIFF
--- a/quippy/quippy/farray.py
+++ b/quippy/quippy/farray.py
@@ -283,6 +283,17 @@ class FortranArray(np.ndarray):
         "Overloaded __getitem__ which accepts one-based indices."
         if getattr(self, 'parent', None) and self.parent() is None:
             raise RuntimeError("array's parent has gone out of scope!")
+        # logic moved from __getslice__ which is no longer called
+        # from numpy 1.13 and Python 3
+        if isinstance(indx, slice):
+            if indx.start != 0:
+                indx = slice(FortranArray.map_int(indx.start), indx.stop,
+                             indx.step)
+            obj = np.ndarray.__getitem__(self, indx)
+            if isinstance(obj, np.ndarray):
+                fa = obj.view(self.__class__)
+                return fa
+
         indx = self.mapindices(indx)
         obj = np.ndarray.__getitem__(self, indx)
         if isinstance(obj, np.ndarray):
@@ -323,24 +334,13 @@ class FortranArray(np.ndarray):
 
     def __getslice__(self, i, j):
         "Overloaded __getslice__ which accepts one-based indices."
-        if getattr(self, 'parent', None) and self.parent() is None:
-            raise RuntimeError("array's parent has gone out of scope!")
-
-        if i != 0:
-            i = FortranArray.map_int(i)
-        obj = np.ndarray.__getslice__(self, i, j)
-        if isinstance(obj, np.ndarray):
-            fa = obj.view(self.__class__)
-            return fa
+        # Removed in Numpy 1.13 and Python 3
+        return self.__getitem__(slice(i, j))
 
     def __setslice__(self, i, j, value):
         "Overloaded __setslice__ which accepts one-based indices."
-        if getattr(self, 'parent', None) and self.parent() is None:
-            raise RuntimeError("array's parent has gone out of scope!")
-
-        if i != 0:
-            i = FortranArray.map_int(i)
-        np.ndarray.__setslice__(self, i, j, value)
+        # Removed in Numpy 1.13 and Python 3
+        self.__setitem__(slice(i, j), value)
 
     def nonzero(self):
         """Return the one-based indices of the elements of a which are not zero."""

--- a/tests/travis/travis.yml
+++ b/tests/travis/travis.yml
@@ -115,7 +115,6 @@ install:
   # stdout is redirected as it generates too much output.
   # FIXME: numpy version mask
   - if [ "${RUN}" == "true" ]; then
-      pip install "numpy<1.13.0";
       gfortran --version;
       gcc --version;
       g++ --version;


### PR DESCRIPTION
The methods are replaced with ``_getindex__(slice(i, j))`` in
Python 3 and Numpy 1.13

Required logic for Fortran indexing is moved into ``__getindex__``

Travis testing will run with newest Numpy.

All the tests pass on both 1.12 and 1.13. Closes #75