### PR TITLE
Change property names for ase-3.15

### DIFF
--- a/quippy/quippy/atoms.py
+++ b/quippy/quippy/atoms.py
@@ -310,7 +310,8 @@ class Atoms(_atoms.Atoms, ase.Atoms):
 
     name_map = {'positions'       : 'pos',
                 'numbers'         : 'Z',
-                'charges'         : 'charge'}
+                'initial_charges' : 'charge',
+                'initial_magmoms' : 'magmoms'}
 
     rev_name_map = dict(zip(name_map.values(), name_map.keys()))
 
@@ -738,8 +739,8 @@ class Atoms(_atoms.Atoms, ase.Atoms):
                     self.params['spacegroup'] = other.info['spacegroup'].symbol
 
             # create extra properties for any non-standard arrays
-            standard_ase_arrays = ['positions', 'numbers', 'masses', 'charges',
-                                   'momenta', 'tags', 'magmoms' ]
+            standard_ase_arrays = ['positions', 'numbers', 'masses', 'initial_charges',
+                                   'momenta', 'tags', 'initial_magmoms' ]
 
             for ase_name, value in other.arrays.iteritems():
                 quippy_name = self.name_map.get(ase_name, ase_name)


### PR DESCRIPTION
In the latest ase release, some of the names used internally for `.arrays` has been changed to distinguish between initial and calculated values. This quick fix makes the tests work, but I'm not sure it is the correct or best solution, so will wait for comments from @jameskermode 

`charges` -> `initial_charges`
`magmoms` -> `initial_magmoms`

(this PR will make tests fail on ase<3.15)

fixes #85