### PR TITLE
Add option to parallelise GAP over descriptors, not atoms

### DIFF
--- a/src/Potentials/IPModel_GAP.f95
+++ b/src/Potentials/IPModel_GAP.f95
@@ -428,9 +428,9 @@ subroutine IPModel_GAP_Calc(this, at, e, local_e, f, virial, local_virial, args_
      loop_over_descriptor_instances: do i = 1, size(my_descriptor_data%x)
         if( .not. my_descriptor_data%x(i)%has_data ) cycle
 
-        if (mpi_parallel_descriptor .and. present(mpi)) then
+        if (mpi_parallel_descriptor .and. mpi%active) then
             ! This blocking strategy should yield a good, memory-local distribution of descriptors to processors
-           if (.not. ((i - 1) * size(my_descriptor_data%x) / mpi%n_procs) == (mpi%my_proc - 1)) cycle
+           if (.not. ((i - 1) * mpi%n_procs / size(my_descriptor_data%x)) == (mpi%my_proc - 1)) cycle
         endif
 
         !call system_timer('IPModel_GAP_Calc_gp_predict')

--- a/src/Potentials/IPModel_GAP.f95
+++ b/src/Potentials/IPModel_GAP.f95
@@ -430,7 +430,7 @@ subroutine IPModel_GAP_Calc(this, at, e, local_e, f, virial, local_virial, args_
 
         if (mpi_parallel_descriptor .and. mpi%active) then
             ! This blocking strategy should yield a good, memory-local distribution of descriptors to processors
-           if (.not. ((i - 1) * mpi%n_procs / size(my_descriptor_data%x)) == (mpi%my_proc - 1)) cycle
+           if (.not. ((i - 1) * mpi%n_procs / size(my_descriptor_data%x)) == mpi%my_proc) cycle
         endif
 
         !call system_timer('IPModel_GAP_Calc_gp_predict')
@@ -541,8 +541,10 @@ subroutine IPModel_GAP_Calc(this, at, e, local_e, f, virial, local_virial, args_
         endif
         if(do_energy_per_coordinate) call sum_in_place(mpi,energy_per_coordinate)
 
-        if (.not. mpi_parallel_descriptor) call remove_property(at,'mpi_local_mask', error=error)
-        deallocate(mpi_local_mask)
+        if (.not. mpi_parallel_descriptor) then
+           call remove_property(at,'mpi_local_mask', error=error)
+           deallocate(mpi_local_mask)
+        endif
      endif
   endif
 


### PR DESCRIPTION
This strategy seems to significantly improve the scaling for certain descriptors, such as general dimer, where the number of descriptors is much larger than the number of atoms.

Changes will be merged once I verify the correctness of the new parallelised GAP.