### PR TITLE
converter copying values from info/arrays on demand

### DIFF
--- a/quippy/quippy/convert.py
+++ b/quippy/quippy/convert.py
@@ -38,22 +38,25 @@ __all__ = ['ase_to_quip', 'descriptor_data_mono_to_dict', 'velocities_ase_to_qui
 MASSCONVERT = 103.6426957074462
 
 
-def ase_to_quip(ase_atoms: ase.Atoms, quip_atoms=None, add_properties=None):
+def ase_to_quip(ase_atoms: ase.Atoms, quip_atoms=None, add_arrays=None, add_info=None):
     """
     Converter to put the info from an ase atoms object into a quip atoms object.
     Copies everything to make sure there is not linking back.
 
-    Notes on add_properties:
+    Notes on add_arrays and add_info:
         - overwriting a parameter is not possible yet
         - only float arrays can be added, integers are converted to floats by fortran, fails for strings
         - keys can only be strings, as the fortran dictionary will not accept anything else,\
         integer keys are converted to strings
+        - possible types:
+            None - only the basic ones
+            list - all the list elements are added
+            True - all of the arrays
 
     :param ase_atoms:
     :param quip_atoms:
-    :param add_properties:  None - only the basic ones
-                            list - all the list elements are added
-                            True - all of the arrays
+    :param add_arrays: keys to take from ase.Atoms.arrays
+    :param add_info:  keys to take from ase.Atoms.info
     :return:
     """
 
@@ -87,22 +90,22 @@ def ase_to_quip(ase_atoms: ase.Atoms, quip_atoms=None, add_properties=None):
                                                     value=velocities_ase_to_quip(ase_atoms.get_velocities()))
 
     # go through all properties for issue#170
-    if add_properties is not None:
-        if add_properties is True:
+    if add_arrays is not None:
+        if add_arrays is True:
             # taking all the array keys that are not handled elsewhere
-            add_properties = set(ase_atoms.arrays.keys())
-            [add_properties.discard(used_key) for used_key in ['numbers', 'positions', 'momenta']]
-            add_properties = list(add_properties)
-        elif isinstance(add_properties, str):
+            add_arrays = set(ase_atoms.arrays.keys())
+            [add_arrays.discard(used_key) for used_key in ['numbers', 'positions', 'momenta']]
+            add_arrays = list(add_arrays)
+        elif isinstance(add_arrays, str):
             # if only one is given as a string
-            add_properties = [add_properties]
-        elif isinstance(add_properties, list) or isinstance(add_properties, np.ndarray):
-            add_properties = list(add_properties)
+            add_arrays = [add_arrays]
+        elif isinstance(add_arrays, list) or isinstance(add_arrays, np.ndarray):
+            add_arrays = list(add_arrays)
         else:
             # fixme: decide what to do here, now it is just not adding anything
-            add_properties = []
+            add_arrays = []
 
-        for property_name in add_properties:
+        for property_name in add_arrays:
             try:
                 value = np.array(ase_atoms.arrays[property_name])
             except KeyError:

--- a/quippy/quippy/convert.py
+++ b/quippy/quippy/convert.py
@@ -89,10 +89,10 @@ def ase_to_quip(ase_atoms: ase.Atoms, quip_atoms=None, add_arrays=None, add_info
         _quippy.f90wrap_atoms_add_property_real_2da(this=quip_atoms._handle, name='velo',
                                                     value=velocities_ase_to_quip(ase_atoms.get_velocities()))
 
-    def key_spec_to_list(keyspec, exclude=[]):
+    def key_spec_to_list(keyspec, default, exclude=[]):
         if keyspec is True:
             # taking all the array keys that are not handled elsewhere
-            keyspec = set(ase_atoms.arrays.keys())
+            keyspec = set(default.keys())
             [keyspec.discard(used_key) for used_key in exclude]
             keyspec = list(keyspec)
         elif isinstance(keyspec, str):
@@ -108,7 +108,7 @@ def ase_to_quip(ase_atoms: ase.Atoms, quip_atoms=None, add_arrays=None, add_info
 
     # go through all properties for issue#170
     if add_arrays is not None:
-        add_arrays = key_spec_to_list(add_arrays, exclude=['numbers', 'positions', 'momenta'])
+        add_arrays = key_spec_to_list(add_arrays, ase_atoms.arrays, exclude=['numbers', 'positions', 'momenta'])
         for info_name in add_arrays:
             try:
                 value = np.array(ase_atoms.arrays[info_name])
@@ -118,7 +118,7 @@ def ase_to_quip(ase_atoms: ase.Atoms, quip_atoms=None, add_arrays=None, add_info
             add_value(quip_atoms, info_name, value)
 
     if add_info is not None:
-        add_info = key_spec_to_list(add_info, exclude=[])
+        add_info = key_spec_to_list(add_info, ase_atoms.info, exclude=[])
         for info_name in add_info:
             try:
                 value = np.array(ase_atoms.info[info_name])

--- a/quippy/quippy/potential.py
+++ b/quippy/quippy/potential.py
@@ -61,7 +61,7 @@ class Potential(ase.calculators.calculator.Calculator):
         finalise=True
     """)
     def __init__(self, args_str="", param_str=None, atoms=None, calculation_always_required=False, param_filename=None,
-                 calc_args=None, **kwargs):
+                 calc_args=None, add_arrays=None, add_info=None, **kwargs):
         quippy.potential_module.Potential.__init__.__doc__
 
         self._default_properties = ['energy', 'forces']
@@ -77,6 +77,9 @@ class Potential(ase.calculators.calculator.Calculator):
             self._quip_potential = quippy.potential_module.Potential(args_str=args_str, param_str=param_str)
         # init the quip atoms as None, to have the variable
         self._quip_atoms = None
+        # init the info and array keys that need to be added when converting atoms objects
+        self.add_arrays = add_arrays
+        self.add_info = add_info
 
         # from old
         if atoms is not None:
@@ -173,7 +176,10 @@ class Potential(ase.calculators.calculator.Calculator):
             return
 
         # construct the quip atoms object which we will use to calculate on
-        self._quip_atoms = quippy.convert.ase_to_quip(self.atoms, add_arrays=add_arrays, add_info=add_info)
+        # if add_arrays/add_info given to this object is not None, then OVERWRITES the value set in __init__
+        self._quip_atoms = quippy.convert.ase_to_quip(self.atoms,
+                                                      add_arrays=add_arrays if add_arrays is not None else self.add_arrays,
+                                                      add_info=add_info if add_info is not None else self.add_info)
 
         # constructing args_string with automatically aliasing the calculateable non-quippy properties
         # calc_args string to be passed to Fortran code

--- a/quippy/quippy/potential.py
+++ b/quippy/quippy/potential.py
@@ -120,7 +120,7 @@ class Potential(ase.calculators.calculator.Calculator):
     def calculate(self, atoms=None, properties=None, system_changes=None,
                   forces=None, virial=None, local_energy=None,
                   local_virial=None, vol_per_atom=None,
-                  copy_all_properties=True, calc_args=None, **kwargs):
+                  copy_all_properties=True, calc_args=None, add_properties=None, **kwargs):
 
         # handling the property inputs
         if properties is None:
@@ -172,7 +172,7 @@ class Potential(ase.calculators.calculator.Calculator):
             return
 
         # construct the quip atoms object which we will use to calculate on
-        self._quip_atoms = quippy.convert.ase_to_quip(self.atoms)
+        self._quip_atoms = quippy.convert.ase_to_quip(self.atoms, add_properties=add_properties)
 
         # constructing args_string with automatically aliasing the calculateable non-quippy properties
         # calc_args string to be passed to Fortran code

--- a/quippy/quippy/potential.py
+++ b/quippy/quippy/potential.py
@@ -120,7 +120,8 @@ class Potential(ase.calculators.calculator.Calculator):
     def calculate(self, atoms=None, properties=None, system_changes=None,
                   forces=None, virial=None, local_energy=None,
                   local_virial=None, vol_per_atom=None,
-                  copy_all_properties=True, calc_args=None, add_properties=None, **kwargs):
+                  copy_all_properties=True, calc_args=None, add_arrays=None,
+                  add_info=None **kwargs):
 
         # handling the property inputs
         if properties is None:
@@ -172,7 +173,7 @@ class Potential(ase.calculators.calculator.Calculator):
             return
 
         # construct the quip atoms object which we will use to calculate on
-        self._quip_atoms = quippy.convert.ase_to_quip(self.atoms, add_properties=add_properties)
+        self._quip_atoms = quippy.convert.ase_to_quip(self.atoms, add_arrays=add_arrays, add_info=add_info)
 
         # constructing args_string with automatically aliasing the calculateable non-quippy properties
         # calc_args string to be passed to Fortran code

--- a/quippy/quippy/potential.py
+++ b/quippy/quippy/potential.py
@@ -121,7 +121,7 @@ class Potential(ase.calculators.calculator.Calculator):
                   forces=None, virial=None, local_energy=None,
                   local_virial=None, vol_per_atom=None,
                   copy_all_properties=True, calc_args=None, add_arrays=None,
-                  add_info=None **kwargs):
+                  add_info=None, **kwargs):
 
         # handling the property inputs
         if properties is None:

--- a/quippy/quippy/potential.py
+++ b/quippy/quippy/potential.py
@@ -108,6 +108,23 @@ class Potential(ase.calculators.calculator.Calculator):
         'pbc', 'initial_charges' and 'initial_magmoms'.
     calc_args: argument string to pass to Fortran calc() routine.
         This is appended to `self.calc_args`, if this is set.
+    add_arrays: list, str or True
+        Arrays to carry over from `atoms.arrays` to the Fortran atoms object when calling calculate()
+        If the same argument is filled in calculate, then it will overwrite this.
+        String arrays not supported.
+        possible types:
+            None - only defaults: `pos`, `Z`, `cell`, `pbc`, `momenta` (as velo, if exists)
+            str  - single key
+            list - all list elements as keys
+            True - all of the arrays from `atoms.arrays`
+    add_info: list, str or True
+        Info to carry over from `atoms.info` to the Fortran atoms object when calling calculate()
+        If the same argument is filled in calculate, then it will overwrite this.
+        possible types:
+            None - only defaults: `pos`, `Z`, `cell`, `pbc`, `momenta` (as velo, if exists)
+            str  - single key
+            list - all list elements as keys
+            True - all of the values from `atoms.info`
 
     Arrays can also be passed directly to the Fortran routine using
     the `forces`, `virial`, `local_energy`, `local_virial`

--- a/tests/quippytest.py
+++ b/tests/quippytest.py
@@ -69,11 +69,21 @@ class QuippyTestCase(unittest.TestCase):
 
         absdiff = abs(first - second)
         if np.max(absdiff) > tol:
-            print('First array: \n', first)
-            print('\n \n Second array: \n', second)
-            print('\n \n Abs Difference: \n', absdiff)
-            self.fail('Maximum abs difference between array elements is %e at location %r' % (np.max(absdiff),
-                                                                                              np.argmax(absdiff)))
+            print('First array:\n{}'.format(first))
+            print('\n \n Second array:\n{}'.format(second))
+            print('\n \n Abs Difference:\n{}'.format(absdiff))
+            self.fail('Maximum abs difference between array elements is {} at location {}'.format(np.max(absdiff),
+                                                                                                  np.argmax(absdiff)))
+
+    def assertArrayIntEqual(self, first, second):
+        first = np.array(first)
+        second = np.array(second)
+        self.assertEqual(first.shape, second.shape)
+
+        if not np.all(first == second):
+            print('First array:\n{}'.format(first))
+            print('\n \n Second array:\n{}'.format(second))
+            self.fail('Two bool arrays not matching, difference is\n {}'.format(first == second))
 
 
 def skip(f):

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -63,83 +63,83 @@ class Test_Converter(quippytest.QuippyTestCase):
 
         # fixme this is a hack to get the first element of the array
         # real
-        raw_info = self._convert_at_add_arrays(at, add_info='real')
-        self.assertAlmostEqual(raw_info['real'][0], self.ref_info['real'], delta=1E-06)
+        raw_dict_output = self._convert_at_add_arrays_and_info(at, add_info='real')
+        self.assertAlmostEqual(raw_dict_output['real'], self.ref_info['real'], delta=1E-06)
 
         # logical
-        raw_info = self._convert_at_add_arrays(at, add_info=['logical_T', 'logical_F'])
-        self.assertEqual(raw_info['logical_T'][0], self.ref_info['logical_T'])
-        self.assertEqual(raw_info['logical_F'][0], self.ref_info['logical_F'])
+        raw_dict_output = self._convert_at_add_arrays_and_info(at, add_info=['logical_T', 'logical_F'])
+        self.assertEqual(raw_dict_output['logical_T'], self.ref_info['logical_T'])
+        self.assertEqual(raw_dict_output['logical_F'], self.ref_info['logical_F'])
 
         # integer
-        raw_info = self._convert_at_add_arrays(at, add_info=['integer'])
-        self.assertEqual(raw_info['integer'][0], self.ref_info['integer'])
+        raw_dict_output = self._convert_at_add_arrays_and_info(at, add_info=['integer'])
+        self.assertEqual(raw_dict_output['integer'], self.ref_info['integer'])
 
     def test_convert_add_arguent_types(self):
         # testing the different ways of specifying arguments
 
         # None
-        raw_none = self._convert_at_add_arrays(self.at_base, add_info=None)
+        raw_dict_output = self._convert_at_add_arrays_and_info(self.at_base, add_info=None)
         for key in self.at_base.arrays.keys():
-            self.assertNotIn(key, raw_none.keys())
+            self.assertNotIn(key, raw_dict_output.keys())
         for key in self.at_base.info.keys():
-            self.assertNotIn(key, raw_none.keys())
+            self.assertNotIn(key, raw_dict_output.keys())
 
         # string
-        raw_none = self._convert_at_add_arrays(self.at_base, add_info='real')
-        self.assertIn('real', raw_none.keys())
+        raw_dict_output = self._convert_at_add_arrays_and_info(self.at_base, add_info='real')
+        self.assertIn('real', raw_dict_output.keys())
 
         # list
-        raw_none = self._convert_at_add_arrays(self.at_base, add_info=['real'])
-        self.assertIn('real', raw_none.keys())
+        raw_dict_output = self._convert_at_add_arrays_and_info(self.at_base, add_info=['real'])
+        self.assertIn('real', raw_dict_output.keys())
 
         # tuple
-        raw_none = self._convert_at_add_arrays(self.at_base, add_info=('real'))
-        self.assertIn('real', raw_none.keys())
+        raw_dict_output = self._convert_at_add_arrays_and_info(self.at_base, add_info=('real'))
+        self.assertIn('real', raw_dict_output.keys())
 
         # np.array
-        raw_none = self._convert_at_add_arrays(self.at_base, add_info=np.array(['real']))
-        self.assertIn('real', raw_none.keys())
+        raw_dict_output = self._convert_at_add_arrays_and_info(self.at_base, add_info=np.array(['real']))
+        self.assertIn('real', raw_dict_output.keys())
 
         # True
-        raw_none = self._convert_at_add_arrays(self.at_base, add_info=True, add_arrays=True)
-        self.assertIn('real', raw_none.keys())
+        raw_dict_output = self._convert_at_add_arrays_and_info(self.at_base, add_info=True, add_arrays=True)
+        self.assertIn('real', raw_dict_output.keys())
         for key in self.at_base.arrays.keys():
             if key in ['numbers', 'positions', 'momenta']:
                 continue
-            self.assertIn(key, raw_none.keys())
+            self.assertIn(key, raw_dict_output.keys())
         for key in self.at_base.info.keys():
-            self.assertIn(key, raw_none.keys())
+            self.assertIn(key, raw_dict_output.keys())
 
     def test_convert_add_wrong_shape(self):
         """ Passing an array of the wrong shape"""
         # setup of a separate atoms for this test
         at = self.at_base.copy()
         at.arrays['wrong_shape'] = np.zeros((1, 6), dtype=float)
-        self.assertRaises(RuntimeError, self._convert_at_add_arrays, at, add_arrays='wrong_shape')
+        self.assertRaises(RuntimeError, self._convert_at_add_arrays_and_info, at, add_arrays='wrong_shape')
 
     def test_convert_add_real(self):
         # default
-        raw_arrays = self._convert_at_add_arrays(self.at_base)
-        self.assertNotIn('dummy_real_2d', raw_arrays.keys())
-        self.assertNotIn('dummy_real_1d', raw_arrays.keys())
+        raw_dict_output = self._convert_at_add_arrays_and_info(self.at_base)
+        self.assertNotIn('dummy_real_2d', raw_dict_output.keys())
+        self.assertNotIn('dummy_real_1d', raw_dict_output.keys())
 
         # 2d only
-        raw_arrays = self._convert_at_add_arrays(self.at_base, add_arrays='dummy_real_2d')
-        self.assertArrayAlmostEqual(raw_arrays['dummy_real_2d'], self.ref_real_2d.T, tol=1E-06)
+        raw_dict_output = self._convert_at_add_arrays_and_info(self.at_base, add_arrays='dummy_real_2d')
+        self.assertArrayAlmostEqual(raw_dict_output['dummy_real_2d'], self.ref_real_2d.T, tol=1E-06)
 
         # 1d only
-        raw_arrays = self._convert_at_add_arrays(self.at_base, add_arrays=['dummy_real_1d'])
-        self.assertArrayAlmostEqual(raw_arrays['dummy_real_1d'], self.ref_real_1d, tol=1E-06)
+        raw_dict_output = self._convert_at_add_arrays_and_info(self.at_base, add_arrays=['dummy_real_1d'])
+        self.assertArrayAlmostEqual(raw_dict_output['dummy_real_1d'], self.ref_real_1d, tol=1E-06)
 
     def test_convert_add_int(self):
         # 2d only
-        raw_arrays = self._convert_at_add_arrays(self.at_base, add_arrays='dummy_int_2d')
-        self.assertArrayIntEqual(raw_arrays['dummy_int_2d'], self.ref_int_2d.T)
+        raw_dict_output = self._convert_at_add_arrays_and_info(self.at_base, add_arrays='dummy_int_2d')
+        self.assertArrayIntEqual(raw_dict_output['dummy_int_2d'], self.ref_int_2d.T)
 
         # 1d only
-        raw_arrays = self._convert_at_add_arrays(self.at_base, add_arrays=['dummy_int_1d'])
-        self.assertArrayIntEqual(raw_arrays['dummy_int_1d'], self.ref_int_1d)
+        raw_dict_output = self._convert_at_add_arrays_and_info(self.at_base, add_arrays=['dummy_int_1d'])
+        self.assertArrayIntEqual(raw_dict_output['dummy_int_1d'], self.ref_int_1d)
 
     def test_convert_add_arrays_bool(self):
         # setup of a separate atoms for this test
@@ -148,11 +148,11 @@ class Test_Converter(quippytest.QuippyTestCase):
         at.arrays['dummy_bool_2d'] = self.ref_bool_2d
 
         # 1d bool array
-        raw_arrays = self._convert_at_add_arrays(at, add_arrays='dummy_bool_1d')
-        self.assertArrayIntEqual(raw_arrays['dummy_bool_1d'], self.ref_bool_1d)
+        raw_dict_output = self._convert_at_add_arrays_and_info(at, add_arrays='dummy_bool_1d')
+        self.assertArrayIntEqual(raw_dict_output['dummy_bool_1d'], self.ref_bool_1d)
 
         # 2d bool array
-        self.assertRaises(TypeError, self._convert_at_add_arrays, at, add_arrays='dummy_bool_2d')
+        self.assertRaises(TypeError, self._convert_at_add_arrays_and_info, at, add_arrays='dummy_bool_2d')
 
     def test_convert_add_arrays_unsupported_types(self):
         # setup of a separate atoms for this test
@@ -162,14 +162,20 @@ class Test_Converter(quippytest.QuippyTestCase):
                          dummy_void_2d=np.zeros((3, 4), dtype=np.void))
 
         # all should raise an error, the
-        self.assertRaises(TypeError, self._convert_at_add_arrays, at, add_arrays='dummy_obj_2d')
-        self.assertRaises(TypeError, self._convert_at_add_arrays, at, add_arrays='dummy_void_2d')
-        self.assertRaises(TypeError, self._convert_at_add_arrays, at, add_arrays='dummy_cplx_2d')
+        self.assertRaises(TypeError, self._convert_at_add_arrays_and_info, at, add_arrays='dummy_obj_2d')
+        self.assertRaises(TypeError, self._convert_at_add_arrays_and_info, at, add_arrays='dummy_void_2d')
+        self.assertRaises(TypeError, self._convert_at_add_arrays_and_info, at, add_arrays='dummy_cplx_2d')
 
     @staticmethod
-    def _convert_at_add_arrays(at, add_info=None, add_arrays=None):
+    def _convert_at_add_arrays_and_info(at, add_info=None, add_arrays=None):
+        """
+        Method for calling the converter and returning both the arrays and info in one dict.
+        Yes, clashes are possible between keys but the tests don't need that right now.
+        """
         at_quip = quippy.convert.ase_to_quip(at, add_arrays=add_arrays, add_info=add_info)
         raw_arrays = quippy.convert.get_dict_arrays(at_quip.properties)
+        raw_info = quippy.convert.get_dict_arrays(at_quip.params)
+        raw_arrays.update(raw_info)
         return raw_arrays
 
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -35,25 +35,142 @@ class Test_Converter(quippytest.QuippyTestCase):
                                      [0.2, 0., 0.],
                                      [0.03, 0., 24.]])
 
+        self.ref_int_1d = np.array([0, 0, 11, 24])
+        self.ref_int_2d = np.array([[0, 0, 11],
+                                    [1, 9, 0],
+                                    [2, 0, 0],
+                                    [3, 0, 24]])
+
+        self.ref_str_1d = np.array(['a', 'b', 'c', 'd'])
+        self.ref_str_2d = np.array([['a', 'b'],
+                                    ['c', 'd'],
+                                    ['a', 'r'],
+                                    ['f', 'd']])
+
         self.at_base.arrays['dummy_real_1d'] = self.ref_real_1d
         self.at_base.arrays['dummy_real_2d'] = self.ref_real_2d
+        self.at_base.arrays['dummy_int_1d'] = self.ref_int_1d
+        self.at_base.arrays['dummy_int_2d'] = self.ref_int_2d
 
-    def test_convert_add_properties(self):
+        self.ref_bool_1d = np.array([True, False, True, True])
+        self.ref_bool_2d = np.zeros((2, 4), dtype=bool)
+
+        self.ref_info = dict(real=0.2, logical_T=True, logical_F=False, integer=2)
+        self.at_base.info.update(self.ref_info)
+
+    def test_convert_add_from_info(self):
+        at = self.at_base.copy()
+
+        # fixme this is a hack to get the first element of the array
+        # real
+        raw_info = self._convert_at_add_arrays(at, add_info='real')
+        self.assertAlmostEqual(raw_info['real'][0], self.ref_info['real'], delta=1E-06)
+
+        # logical
+        raw_info = self._convert_at_add_arrays(at, add_info=['logical_T', 'logical_F'])
+        self.assertEqual(raw_info['logical_T'][0], self.ref_info['logical_T'])
+        self.assertEqual(raw_info['logical_F'][0], self.ref_info['logical_F'])
+
+        # integer
+        raw_info = self._convert_at_add_arrays(at, add_info=['integer'])
+        self.assertEqual(raw_info['integer'][0], self.ref_info['integer'])
+
+    def test_convert_add_arguent_types(self):
+        # testing the different ways of specifying arguments
+
+        # None
+        raw_none = self._convert_at_add_arrays(self.at_base, add_info=None)
+        for key in self.at_base.arrays.keys():
+            self.assertNotIn(key, raw_none.keys())
+        for key in self.at_base.info.keys():
+            self.assertNotIn(key, raw_none.keys())
+
+        # string
+        raw_none = self._convert_at_add_arrays(self.at_base, add_info='real')
+        self.assertIn('real', raw_none.keys())
+
+        # list
+        raw_none = self._convert_at_add_arrays(self.at_base, add_info=['real'])
+        self.assertIn('real', raw_none.keys())
+
+        # tuple
+        raw_none = self._convert_at_add_arrays(self.at_base, add_info=('real'))
+        self.assertIn('real', raw_none.keys())
+
+        # np.array
+        raw_none = self._convert_at_add_arrays(self.at_base, add_info=np.array(['real']))
+        self.assertIn('real', raw_none.keys())
+
+        # True
+        raw_none = self._convert_at_add_arrays(self.at_base, add_info=True, add_arrays=True)
+        self.assertIn('real', raw_none.keys())
+        for key in self.at_base.arrays.keys():
+            if key in ['numbers', 'positions', 'momenta']:
+                continue
+            self.assertIn(key, raw_none.keys())
+        for key in self.at_base.info.keys():
+            self.assertIn(key, raw_none.keys())
+
+    def test_convert_add_wrong_shape(self):
+        """ Passing an array of the wrong shape"""
+        # setup of a separate atoms for this test
+        at = self.at_base.copy()
+        at.arrays['wrong_shape'] = np.zeros((1, 6), dtype=float)
+        self.assertRaises(RuntimeError, self._convert_at_add_arrays, at, add_arrays='wrong_shape')
+
+    def test_convert_add_real(self):
         # default
-        at_quip = quippy.convert.ase_to_quip(self.at_base)
-        raw_arrays = quippy.convert.get_dict_arrays(at_quip.properties)
+        raw_arrays = self._convert_at_add_arrays(self.at_base)
         self.assertNotIn('dummy_real_2d', raw_arrays.keys())
         self.assertNotIn('dummy_real_1d', raw_arrays.keys())
 
         # 2d only
-        at_quip = quippy.convert.ase_to_quip(self.at_base, add_arrays='dummy_real_2d')
-        raw_arrays = quippy.convert.get_dict_arrays(at_quip.properties)
+        raw_arrays = self._convert_at_add_arrays(self.at_base, add_arrays='dummy_real_2d')
         self.assertArrayAlmostEqual(raw_arrays['dummy_real_2d'], self.ref_real_2d.T, tol=1E-06)
 
         # 1d only
-        at_quip = quippy.convert.ase_to_quip(self.at_base, add_arrays=['dummy_real_1d'])
-        raw_arrays = quippy.convert.get_dict_arrays(at_quip.properties)
+        raw_arrays = self._convert_at_add_arrays(self.at_base, add_arrays=['dummy_real_1d'])
         self.assertArrayAlmostEqual(raw_arrays['dummy_real_1d'], self.ref_real_1d, tol=1E-06)
+
+    def test_convert_add_int(self):
+        # 2d only
+        raw_arrays = self._convert_at_add_arrays(self.at_base, add_arrays='dummy_int_2d')
+        self.assertArrayIntEqual(raw_arrays['dummy_int_2d'], self.ref_int_2d.T)
+
+        # 1d only
+        raw_arrays = self._convert_at_add_arrays(self.at_base, add_arrays=['dummy_int_1d'])
+        self.assertArrayIntEqual(raw_arrays['dummy_int_1d'], self.ref_int_1d)
+
+    def test_convert_add_arrays_bool(self):
+        # setup of a separate atoms for this test
+        at = self.at_base.copy()
+        at.arrays['dummy_bool_1d'] = self.ref_bool_1d
+        at.arrays['dummy_bool_2d'] = self.ref_bool_2d
+
+        # 1d bool array
+        raw_arrays = self._convert_at_add_arrays(at, add_arrays='dummy_bool_1d')
+        self.assertArrayIntEqual(raw_arrays['dummy_bool_1d'], self.ref_bool_1d)
+
+        # 2d bool array
+        self.assertRaises(TypeError, self._convert_at_add_arrays, at, add_arrays='dummy_bool_2d')
+
+    def test_convert_add_arrays_unsupported_types(self):
+        # setup of a separate atoms for this test
+        at = self.at_base.copy()
+        at.arrays.update(dummy_obj_2d=np.zeros((3, 4), dtype=np.object),
+                         dummy_cplx_2d=np.zeros((3, 4), dtype=np.complex),
+                         dummy_void_2d=np.zeros((3, 4), dtype=np.void))
+
+        # all should raise an error, the
+        self.assertRaises(TypeError, self._convert_at_add_arrays, at, add_arrays='dummy_obj_2d')
+        self.assertRaises(TypeError, self._convert_at_add_arrays, at, add_arrays='dummy_void_2d')
+        self.assertRaises(TypeError, self._convert_at_add_arrays, at, add_arrays='dummy_cplx_2d')
+
+    @staticmethod
+    def _convert_at_add_arrays(at, add_info=None, add_arrays=None):
+        at_quip = quippy.convert.ase_to_quip(at, add_arrays=add_arrays, add_info=add_info)
+        raw_arrays = quippy.convert.get_dict_arrays(at_quip.properties)
+        return raw_arrays
 
 
 if __name__ == '__main__':

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,0 +1,60 @@
+# HQ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+# HQ X
+# HQ X   quippy: Python interface to QUIP atomistic simulation library
+# HQ X
+# HQ X   Copyright T. K. Stenczel 2019
+# HQ X
+# HQ X   These portions of the source code are released under the GNU General
+# HQ X   Public License, version 2, http://www.gnu.org/copyleft/gpl.html
+# HQ X
+# HQ X   If you would like to license the source code under different terms,
+# HQ X   please contact James Kermode, james.kermode@gmail.com
+# HQ X
+# HQ X   When using this software, please cite the following reference:
+# HQ X
+# HQ X   http://www.jrkermode.co.uk/quippy
+# HQ X
+# HQ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+import quippy
+import quippytest
+import ase
+import numpy as np
+
+
+class Test_Converter(quippytest.QuippyTestCase):
+    def setUp(self):
+        # this is a base atoms object, which is used afterwards
+        self.at_base = ase.Atoms('HCOO', positions=[[0, 0, 0], [1, 0, 0], [2., 0, 0], [3., 0, 0]], cell=[3, 3, 3],
+                                 pbc=True)
+        self.at_base.set_momenta([[0, 0, 0], [1, 0, 0], [2., 0, 0], [5., 0, 0]])
+
+        self.ref_real_1d = np.array([0., 0., 11., 24.])
+        self.ref_real_2d = np.array([[0., 0., 11.],
+                                     [0.1, 6.9, 0.],
+                                     [0.2, 0., 0.],
+                                     [0.03, 0., 24.]])
+
+        self.at_base.arrays['dummy_real_1d'] = self.ref_real_1d
+        self.at_base.arrays['dummy_real_2d'] = self.ref_real_2d
+
+    def test_convert_add_properties(self):
+        # default
+        at_quip = quippy.convert.ase_to_quip(self.at_base)
+        raw_arrays = quippy.convert.get_dict_arrays(at_quip.properties)
+        self.assertNotIn('dummy_real_2d', raw_arrays.keys())
+        self.assertNotIn('dummy_real_1d', raw_arrays.keys())
+
+        # 2d only
+        at_quip = quippy.convert.ase_to_quip(self.at_base, add_properties='dummy_real_2d')
+        raw_arrays = quippy.convert.get_dict_arrays(at_quip.properties)
+        self.assertArrayAlmostEqual(raw_arrays['dummy_real_2d'], self.ref_real_2d.T, tol=1E-06)
+
+        # 1d only
+        at_quip = quippy.convert.ase_to_quip(self.at_base, add_properties=['dummy_real_1d'])
+        raw_arrays = quippy.convert.get_dict_arrays(at_quip.properties)
+        self.assertArrayAlmostEqual(raw_arrays['dummy_real_1d'], self.ref_real_1d, tol=1E-06)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -46,12 +46,12 @@ class Test_Converter(quippytest.QuippyTestCase):
         self.assertNotIn('dummy_real_1d', raw_arrays.keys())
 
         # 2d only
-        at_quip = quippy.convert.ase_to_quip(self.at_base, add_properties='dummy_real_2d')
+        at_quip = quippy.convert.ase_to_quip(self.at_base, add_arrays='dummy_real_2d')
         raw_arrays = quippy.convert.get_dict_arrays(at_quip.properties)
         self.assertArrayAlmostEqual(raw_arrays['dummy_real_2d'], self.ref_real_2d.T, tol=1E-06)
 
         # 1d only
-        at_quip = quippy.convert.ase_to_quip(self.at_base, add_properties=['dummy_real_1d'])
+        at_quip = quippy.convert.ase_to_quip(self.at_base, add_arrays=['dummy_real_1d'])
         raw_arrays = quippy.convert.get_dict_arrays(at_quip.properties)
         self.assertArrayAlmostEqual(raw_arrays['dummy_real_1d'], self.ref_real_1d, tol=1E-06)
 


### PR DESCRIPTION
solution for #170 
Adding ability to pass arrays or info from `ase.Atoms` object to the fortran objects. With test.

`add_info` and `add_arrays` parameters can be passed to `quippy.potential.Potential.__init__()` for keys from the info and arrays dictionaries to be passed to the fortran atoms object when calling calculate, even internally, so `potential.get_potential_energy()` will also do it in the background. 

Calling `quippy.potential.Potential.calculate()` with `add_info` and `add_arrays` explicitly (not as None), will overwrite the settings of `__init__`. 

The supported types are detailed in the docstrings (of `quippy.convert.ase_to_quip`) and are working for real and int scalars (as 1d arrays) and arrays  as well, logicals are retrieved as int32.