### PR TITLE
Added ${CP_OPTS} to fix compilation on CSD3

### DIFF
--- a/arch/Makefile.csd3_x86_64_gfortran_openmp
+++ b/arch/Makefile.csd3_x86_64_gfortran_openmp
@@ -1,0 +1,46 @@
+# H0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+# H0 X
+# H0 X   libAtoms+QUIP: atomistic simulation library
+# H0 X
+# H0 X   Portions of this code were written by
+# H0 X     Albert Bartok-Partay, Silvia Cereda, Gabor Csanyi, James Kermode,
+# H0 X     Ivan Solt, Wojciech Szlachta, Csilla Varnai, Steven Winfield.
+# H0 X
+# H0 X   Copyright 2006-2010.
+# H0 X
+# H0 X   These portions of the source code are released under the GNU General
+# H0 X   Public License, version 2, http://www.gnu.org/copyleft/gpl.html
+# H0 X
+# H0 X   If you would like to license the source code under different terms,
+# H0 X   please contact Gabor Csanyi, gabor@csanyi.net
+# H0 X
+# H0 X   Portions of this code were written by Noam Bernstein as part of
+# H0 X   his employment for the U.S. Government, and are not subject
+# H0 X   to copyright in the USA.
+# H0 X
+# H0 X
+# H0 X   When using this software, please cite the following reference:
+# H0 X
+# H0 X   http://www.libatoms.org
+# H0 X
+# H0 X  Additional contributions by
+# H0 X    Alessio Comisso, Chiara Gattinoni, and Gianpietro Moras
+# H0 X
+# H0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# declarations
+
+include arch/Makefile.linux_x86_64_gfortran
+
+DEFINES += -D_OPENMP
+F95FLAGS += -fopenmp
+F77FLAGS += -fopenmp
+CFLAGS += -fopenmp
+LINKOPTS += -fopenmp
+
+QUIPPY_F90FLAGS += -fopenmp
+QUIPPY_CFLAGS += -fopenmp
+QUIPPY_LDFLAGS += -fopenmp
+
+CP_OPTS="" # needed for CSD3 where `cp -p` would cause problems
+# rules


### PR DESCRIPTION
Needed to change `-p` to `${CP_OPTS}` in some of the files of fox because the CSD3 machine doesn't support the -p option of the cp command. The `${CP_OPTS}` is set in `arch/Makefile.csd3_x86_64_gfortran_openmp`

Also needs the pull request in libatoms/fox: https://github.com/libAtoms/fox/pull/1/commits/c1a2bad2c926595dd13848b79f4d4d1119d6ff95