### PR TITLE
quip_unified_wrapper.f95: remove print line on model update

### DIFF
--- a/src/Potentials/quip_unified_wrapper.f95
+++ b/src/Potentials/quip_unified_wrapper.f95
@@ -117,7 +117,6 @@ subroutine quip_unified_wrapper(N,pos,frac_pos,lattice,symbol,Z, &
   end if
 
   if (optional_default(.false., reload_pot)) then
-    print("potential reloaded in quip_unified_wrapper from file:"//quip_param_file)
     ! deallocate old potential -- this was initialised in first_run
     call Finalise(pot)
     ! initialise with new parameters


### PR DESCRIPTION
I have noticed that I have left an extra print line in the pushed changes last time @albapa, while that was not there locally and seems to be breaking the code. 

Not being sure why though, I thought that the `print` imported here is the Potential's print, so that is why it breaks, but I am not sure. It is not needed there anyways.