### PR TITLE
workaround for failing Docker build due to long function name

### DIFF
--- a/quippy/Makefile
+++ b/quippy/Makefile
@@ -94,7 +94,8 @@ _quippy.so: ${WRAP_FPP_FILES}
 		--shorten-routine-names -k ${QUIPPY_SRC_DIR}/KIND_MAP -s ${QUIPPY_SRC_DIR}/STRING_LENGTHS -S 10240 \
 		--skip atoms_shallowcopy atoms_initialise_ptr atoms_finalise_multi \
 		potential_initialise_inoutput cplx_2d  cplx_2d_array1_finalise \
-		--skip-types spherical_harmonics_type --force-public set_cutoff \
+                potential_local_e_mix_initialise potential_local_e_mix_finalise \
+                --skip-types spherical_harmonics_type potential_local_e_mix --force-public set_cutoff \
 		--documentation-plugin ${QUIPPY_SRC_DIR}/doc_plugin.py \
 		--py-max-line-length 120 --f90-max-line-length 120
 


### PR DESCRIPTION
This should fix failing `quip-gap` Docker build.