### PR TITLE
GCC 10 argument mismatches error 

### DIFF
--- a/src/Utils/force_machine_learning_module.f95
+++ b/src/Utils/force_machine_learning_module.f95
@@ -685,7 +685,7 @@ subroutine  read_distance_file(distance_matrix, data_dir)
 
        call system_timer('Read Pair Distance and Bulid Covariance')
  !      OPEN(2,status='old',file=trim(data_dir)//'Dist.dat',form='UNFORMATTED')
-       call fread_array_d(1, (/distance_matrix(1,1)/), trim(data_dir)//'Dist.dat') 
+       call fread_array_d(1, distance_matrix(1,1:1), trim(data_dir)//'Dist.dat') 
 
        do i=2, size(distance_matrix(:,1))
               call  fread_array_d(i-1, distance_matrix(i,:(i-1)), trim(data_dir)//'Dist.dat')

--- a/src/Utils/force_machine_learning_module.f95
+++ b/src/Utils/force_machine_learning_module.f95
@@ -640,7 +640,7 @@ subroutine write_distance_file_real(d, data_dir)
 !   OPEN(2, status='replace',file=trim(data_dir)//'Dist.dat',  form='UNFORMATTED')
 !   !write(2)  d
 !   close(2)
-    call fwrite_array_d(1, 0.0_dp, trim(data_dir)//'Dist.dat')
+    call fwrite_array_d(1, (/0.0_dp/), trim(data_dir)//'Dist.dat')
 end subroutine write_distance_file_real
 
 !subroutine  refresh_info(data_dir, f_proj, f_norm, ivs_set)
@@ -685,7 +685,7 @@ subroutine  read_distance_file(distance_matrix, data_dir)
 
        call system_timer('Read Pair Distance and Bulid Covariance')
  !      OPEN(2,status='old',file=trim(data_dir)//'Dist.dat',form='UNFORMATTED')
-       call fread_array_d(1, distance_matrix(1,1), trim(data_dir)//'Dist.dat') 
+       call fread_array_d(1, (/distance_matrix(1,1)/), trim(data_dir)//'Dist.dat') 
 
        do i=2, size(distance_matrix(:,1))
               call  fread_array_d(i-1, distance_matrix(i,:(i-1)), trim(data_dir)//'Dist.dat')


### PR DESCRIPTION
**Summary**

This PR contains a simple fix (replacing the scalar with a size-one array) to prevent argument mismatches error in GCC 10. 

**Related Issue(s)**

This PR addresses issue #267 

**Author(s)**

Yaser Afshar @yafshar (UMN)