### PR TITLE
Make system_abort return non-zero status to shell when program exit is triggered by fortran 'stop'

### DIFF
--- a/src/libAtoms/error.f95
+++ b/src/libAtoms/error.f95
@@ -331,7 +331,7 @@ contains
     ! send ourselves a USR1 signal rather than aborting
     call kill(getpid(), SIGUSR1, status)
 #else
-    stop
+    stop 1
 #endif
 #endif
   end subroutine error_abort_with_message


### PR DESCRIPTION
Record smallest commit ever.

Closes #340 