### PR TITLE
Install f90wrap with same options as quippy

### DIFF
--- a/quippy/Makefile
+++ b/quippy/Makefile
@@ -80,7 +80,7 @@ F2PY_LINK_ARGS = $(shell ${PYTHON} -c 'import sys; print(" ".join([arg for arg i
 all: build
 
 f90wrap:
-	${PIP} install "f90wrap>=0.2.6"
+	${PIP} install ${QUIPPY_INSTALL_OPTS} "f90wrap>=0.2.6"
 
 clean:
 	rm -f _quippy${EXT_SUFFIX} ${F90WRAP_FILES} ${WRAP_FPP_FILES}


### PR DESCRIPTION
Pip should use the same options (--user) for f90wrap as for quippy, as given by $QUIPPY_INSTALL_OPTS.