### PR TITLE
Makefiles for Sulis

### DIFF
--- a/arch/Makefile.linux_x86_64_gfortran_Sulis
+++ b/arch/Makefile.linux_x86_64_gfortran_Sulis
@@ -1,0 +1,43 @@
+# H0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+# H0 X
+# H0 X   libAtoms+QUIP: atomistic simulation library
+# H0 X
+# H0 X   Portions of this code were written by
+# H0 X     Albert Bartok-Partay, Silvia Cereda, Gabor Csanyi, James Kermode,
+# H0 X     Ivan Solt, Wojciech Szlachta, Csilla Varnai, Steven Winfield.
+# H0 X
+# H0 X   Copyright 2006-2010.
+# H0 X
+# H0 X   These portions of the source code are released under the GNU General
+# H0 X   Public License, version 2, http://www.gnu.org/copyleft/gpl.html
+# H0 X
+# H0 X   If you would like to license the source code under different terms,
+# H0 X   please contact Gabor Csanyi, gabor@csanyi.net
+# H0 X
+# H0 X   Portions of this code were written by Noam Bernstein as part of
+# H0 X   his employment for the U.S. Government, and are not subject
+# H0 X   to copyright in the USA.
+# H0 X
+# H0 X
+# H0 X   When using this software, please cite the following reference:
+# H0 X
+# H0 X   http://www.libatoms.org
+# H0 X
+# H0 X  Additional contributions by
+# H0 X    Alessio Comisso, Chiara Gattinoni, and Gianpietro Moras
+# H0 X
+# H0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# On Sulis run:
+# module load GCC/10.2.0 OpenMPI/4.0.5 OpenBLAS/0.3.12
+
+# ..and if wanting to build the Python interface
+# module load SciPy-bundle/2020.11
+
+# declarations
+
+include arch/Makefile.linux_x86_64_gfortran
+
+export DEFAULT_MATH_LINKOPTS = -L${EBROOTOPENBLAS}/lib -lopenblas
+
+

--- a/arch/Makefile.linux_x86_64_gfortran_Sulis_openmp
+++ b/arch/Makefile.linux_x86_64_gfortran_Sulis_openmp
@@ -1,0 +1,51 @@
+# H0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+# H0 X
+# H0 X   libAtoms+QUIP: atomistic simulation library
+# H0 X
+# H0 X   Portions of this code were written by
+# H0 X     Albert Bartok-Partay, Silvia Cereda, Gabor Csanyi, James Kermode,
+# H0 X     Ivan Solt, Wojciech Szlachta, Csilla Varnai, Steven Winfield.
+# H0 X
+# H0 X   Copyright 2006-2010.
+# H0 X
+# H0 X   These portions of the source code are released under the GNU General
+# H0 X   Public License, version 2, http://www.gnu.org/copyleft/gpl.html
+# H0 X
+# H0 X   If you would like to license the source code under different terms,
+# H0 X   please contact Gabor Csanyi, gabor@csanyi.net
+# H0 X
+# H0 X   Portions of this code were written by Noam Bernstein as part of
+# H0 X   his employment for the U.S. Government, and are not subject
+# H0 X   to copyright in the USA.
+# H0 X
+# H0 X
+# H0 X   When using this software, please cite the following reference:
+# H0 X
+# H0 X   http://www.libatoms.org
+# H0 X
+# H0 X  Additional contributions by
+# H0 X    Alessio Comisso, Chiara Gattinoni, and Gianpietro Moras
+# H0 X
+# H0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# On Sulis run:
+# module load GCC/10.2.0 OpenMPI/4.0.5 OpenBLAS/0.3.12
+
+# ..and if wanting to build the Python interface
+# module load SciPy-bundle/2020.11
+
+# declarations
+
+include arch/Makefile.linux_x86_64_gfortran_Sulis
+
+# DEFINES += -D_OPENMP # -fopenmp sets this with gcc/gfortran
+F95FLAGS += -fopenmp
+F77FLAGS += -fopenmp
+CFLAGS += -fopenmp
+LINKOPTS += -fopenmp
+
+QUIPPY_F90FLAGS += -fopenmp
+QUIPPY_CFLAGS += -fopenmp
+QUIPPY_LDFLAGS += -fopenmp
+
+# rules

--- a/arch/Makefile.linux_x86_64_gfortran_Sulis_openmpi
+++ b/arch/Makefile.linux_x86_64_gfortran_Sulis_openmpi
@@ -1,0 +1,50 @@
+# H0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+# H0 X
+# H0 X   libAtoms+QUIP: atomistic simulation library
+# H0 X
+# H0 X   Portions of this code were written by
+# H0 X     Albert Bartok-Partay, Silvia Cereda, Gabor Csanyi, James Kermode,
+# H0 X     Ivan Solt, Wojciech Szlachta, Csilla Varnai, Steven Winfield.
+# H0 X
+# H0 X   Copyright 2006-2010.
+# H0 X
+# H0 X   These portions of the source code are released under the GNU General
+# H0 X   Public License, version 2, http://www.gnu.org/copyleft/gpl.html
+# H0 X
+# H0 X   If you would like to license the source code under different terms,
+# H0 X   please contact Gabor Csanyi, gabor@csanyi.net
+# H0 X
+# H0 X   Portions of this code were written by Noam Bernstein as part of
+# H0 X   his employment for the U.S. Government, and are not subject
+# H0 X   to copyright in the USA.
+# H0 X
+# H0 X
+# H0 X   When using this software, please cite the following reference:
+# H0 X
+# H0 X   http://www.libatoms.org
+# H0 X
+# H0 X  Additional contributions by
+# H0 X    Alessio Comisso, Chiara Gattinoni, and Gianpietro Moras
+# H0 X
+# H0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+
+# On Sulis run:
+# module load GCC/10.2.0 OpenMPI/4.0.5 OpenBLAS/0.3.12
+
+# ..and if wanting to build the Python interface
+# module load SciPy-bundle/2020.11
+
+# declarations
+
+include arch/Makefile.linux_x86_64_gfortran_Sulis
+
+F77 = mpif90
+F90 = mpif90
+F95 = mpif90
+CC = mpicc
+CPLUSPLUS = mpicc
+LINKER = mpif90
+FPP = gfortran -E -x f95-cpp-input
+
+DEFINES += -D_MPI


### PR DESCRIPTION
As suggested by @jameskermode, suitable Makefiles for Sulis. Should work for any system with a GCC+OpenMPI+OpenBLAS software stack managed by EasyBuild.

Most of the problems we've encountered with people trying to build QUIP on Sulis arise from a generation of users who've never needed to learn that BLAS implementations other than MKL exist. Since we're on AMD hardware that doesn't go well.