### PR TITLE
Long integer kind

### DIFF
--- a/quippy/KIND_MAP
+++ b/quippy/KIND_MAP
@@ -11,9 +11,7 @@
               'dp':  'complex_double'},
  'integer' : {'':       'int',
              '8':      'long_long',
-             'dp':     'long_long',
+             'idp':     'long_long',
              'c_intptr_t': 'long_long',
              'c_int': 'long_long'}
 }
-
-

--- a/src/Potentials/IPModel_vdW.f95
+++ b/src/Potentials/IPModel_vdW.f95
@@ -43,7 +43,7 @@
 module IPModel_vdW_module
 
 use error_module
-use system_module, only : dp, inoutput, string_to_int, reallocate, system_timer , print, PRINT_NERD
+use system_module, only : idp, dp, inoutput, string_to_int, reallocate, system_timer , print, PRINT_NERD
 use units_module
 use dictionary_module
 use periodictable_module, only: total_elements
@@ -95,7 +95,7 @@ type IPModel_vdW
   type(descriptor), dimension(:), allocatable :: my_descriptor
 #endif
   real(dp), dimension(total_elements) :: e0 = 0.0_dp
-  integer(dp), dimension(total_elements) :: map = -1
+  integer(idp), dimension(total_elements) :: map = -1
   integer :: n_types = 0
   integer, dimension(:), allocatable :: Z
   real(dp), dimension(:), allocatable :: r0

--- a/src/libAtoms/Makefile
+++ b/src/libAtoms/Makefile
@@ -51,6 +51,7 @@ endif
 
 LIBATOMS_F95_FILES = \
   error \
+  kind_module \
   System \
   LinkedList \
   ExtendableStr \

--- a/src/libAtoms/System.f95
+++ b/src/libAtoms/System.f95
@@ -2120,7 +2120,7 @@ contains
        endif
        write(string_cat_real,format) string, r
     else
-       write(string_cat_real,'(i0,a)') string, int(r)
+       write(string_cat_real,'(a,i0)') string, int(r)
     endif
 
   end function string_cat_real

--- a/src/libAtoms/System.f95
+++ b/src/libAtoms/System.f95
@@ -254,7 +254,7 @@ private
   public :: operator(//)
 
   interface operator(//)
-     module procedure string_cat_logical, string_cat_int, string_cat_real, string_cat_real_array
+     module procedure string_cat_logical, string_cat_isp, string_cat_idp, string_cat_real, string_cat_real_array
      module procedure string_cat_complex, string_cat_int_array, string_cat_logical_array
      module procedure string_cat_complex_array, string_cat_string_array
 !     module procedure logical_cat_string, logical_cat_logical, logical_cat_int, logical_cat_real
@@ -347,6 +347,11 @@ private
      module procedure string_to_real_sub, string_to_integer_sub, string_to_logical_sub
      module procedure string_to_real1d, string_to_integer1d, string_to_logical1d
   end interface string_to_numerical
+
+  public :: int_format_length
+  interface int_format_length
+     module procedure int_format_length_isp, int_format_length_idp
+  end interface int_format_length
 
   integer, external :: pointer_to
   public :: increase_stack
@@ -1919,20 +1924,35 @@ contains
     write(string_cat_logical_array,format) string, log
   end function string_cat_logical_array
 
-  elemental function int_format_length(i) result(len)
+  elemental function int_format_length_isp(i) result(len)
     integer, intent(in)::i
     integer::len
     len = max(1,(-sign(1, i)+1)/2 + ceiling(log10(abs(real(i,dp))+0.01_dp)))
-  end function int_format_length
+  end function int_format_length_isp
 
-  function string_cat_int(string, int)
+  elemental function int_format_length_idp(i) result(len)
+    integer(idp), intent(in) :: i
+    integer :: len
+    len = max(1_idp,(-sign(1_idp, i)+1_idp)/2_idp + ceiling(log10(abs(real(i,dp))+0.01_dp), idp))
+  end function int_format_length_idp
+
+  function string_cat_isp(string, int) result(res)
     character(*),      intent(in)  :: string
     integer,           intent(in)  :: int
     ! below we work out the exact length of the resultant string
-    character(len(string)+int_format_length(int)) :: string_cat_int
+    character(len(string)+int_format_length(int)) :: res
 
-    write(string_cat_int,'(a,i0)') string, int
-  end function string_cat_int
+    write(res,'(a,i0)') string, int
+  end function string_cat_isp
+
+  function string_cat_idp(string, int) result(res)
+    character(*),      intent(in)  :: string
+    integer(idp),      intent(in)  :: int
+    ! below we work out the exact length of the resultant string
+    character(len(string)+int_format_length(int)) :: res
+
+    write(res,'(a,i0)') string, int
+  end function string_cat_idp
 
   function int_cat_string(int,string)
     character(*),      intent(in)  :: string

--- a/src/libAtoms/System.f95
+++ b/src/libAtoms/System.f95
@@ -47,6 +47,7 @@
 
 module system_module
   use error_module
+  use kind_module
 !$ use omp_lib
 #ifdef _MPI
 #ifndef _OLDMPI
@@ -66,24 +67,7 @@ private
 
   logical, public :: system_use_fortran_random = .false.
 
-  integer, parameter, public :: isp = selected_int_kind(9)
-  integer, parameter, public :: idp = selected_int_kind(18)
-
-#ifdef HAVE_QP
-  integer, parameter, public :: qp = 16
-#elsif TEN_DIGIT_PRECISION
-  integer, parameter, public :: qp = selected_real_kind(10) !kind(1.0d0)
-#else
-  integer, parameter, public :: qp = 8
-#endif
-
-#ifdef QUAD_PRECISION
-  integer, parameter, public :: dp = 16 ! kind(1.0d0)
-#elsif TEN_DIGIT_PRECISION
-  integer, parameter, public :: dp = selected_real_kind(10) !kind(1.0d0)
-#else
-  integer, parameter, public :: dp = 8 ! kind(1.0d0)
-#endif
+  public :: isp, idp, dp, qp
 
   character, public :: quip_new_line
 

--- a/src/libAtoms/System.f95
+++ b/src/libAtoms/System.f95
@@ -66,6 +66,9 @@ private
 
   logical, public :: system_use_fortran_random = .false.
 
+  integer, parameter, public :: isp = selected_int_kind(9)
+  integer, parameter, public :: idp = selected_int_kind(18)
+
 #ifdef HAVE_QP
   integer, parameter, public :: qp = 16
 #elsif TEN_DIGIT_PRECISION

--- a/src/libAtoms/kind_module.f95
+++ b/src/libAtoms/kind_module.f95
@@ -1,0 +1,24 @@
+module kind_module
+
+  implicit none
+
+  integer, parameter, public :: isp = selected_int_kind(9)
+  integer, parameter, public :: idp = selected_int_kind(18)
+
+#ifdef QUAD_PRECISION
+  integer, parameter, public :: dp = 16
+#elsif TEN_DIGIT_PRECISION
+  integer, parameter, public :: dp = selected_real_kind(10)
+#else
+  integer, parameter, public :: dp = 8
+#endif
+
+#ifdef HAVE_QP
+  integer, parameter, public :: qp = 16
+#elsif TEN_DIGIT_PRECISION
+  integer, parameter, public :: qp = selected_real_kind(10)
+#else
+  integer, parameter, public :: qp = 8
+#endif
+
+end module kind_module


### PR DESCRIPTION
Adds explicit kind variables for 4-byte and 8-byte integers, plus concat operator for long integer.

Putting all kinds into a module for clarity and possible future extensions.