### PR TITLE
fix: reconnect QUIPPY_FCOMPILER to f2py

### DIFF
--- a/quippy/Makefile
+++ b/quippy/Makefile
@@ -113,7 +113,7 @@ ${F90WRAP_FILES}: ${WRAP_FPP_FILES}
 
 quippy/_quippy${EXT_SUFFIX} ${F90WRAP_OBJS}: ${F90WRAP_FILES}
 	F90=${F90} LDFLAGS="${QUIPPY_LDFLAGS}" f2py-f90wrap --build-dir . -c -m _quippy ${F90WRAP_FILES} \
-		-L. -lquip_nostub ${F2PY_LINK_ARGS} --fcompiler=gnu95 --f90flags="${QUIPPY_F90FLAGS}"
+		-L. -lquip_nostub ${F2PY_LINK_ARGS} --fcompiler=${QUIPPY_FCOMPILER} --f90flags="${QUIPPY_F90FLAGS}"
 	mv _quippy${EXT_SUFFIX} quippy/
 
 build: f90wrap quippy/_quippy${EXT_SUFFIX} ${QUIPPY_SRC_DIR}/quippy/*.py


### PR DESCRIPTION
Commit 8321a45570f0acce1c7db40cba86e6482762c684 set `fcompiler=gnu95` option of f2py to fix a Github build problem. This is not necessary and can be reverted.