### PR TITLE
Update potential.py to match the newest ase

### DIFF
--- a/quippy/quippy/potential.py
+++ b/quippy/quippy/potential.py
@@ -100,7 +100,7 @@ class Potential(ase.calculators.calculator.Calculator):
         # from old
         if atoms is not None:
             atoms.calc = self
-        self.name_ = args_str
+        self.name = args_str
         if isinstance(calc_args, dict):
             calc_args = key_val_dict_to_str(calc_args)
         elif calc_args is None:
@@ -111,7 +111,7 @@ class Potential(ase.calculators.calculator.Calculator):
         self.extra_results = {'config': {},
                               'atoms': {}}
 
-    # These two functions below are left in only for purposebackward compatibility, 
+    # These three functions below are left in only for purposebackward compatibility, 
     # we remember to clean it up if/when we decide ASE pre-3.23.0 isn't worth supporting.
     def _get_name(self):
         return self.name_
@@ -119,6 +119,10 @@ class Potential(ase.calculators.calculator.Calculator):
     @property
     def name(self):
         return self._get_name()
+    
+    @name.setter
+    def name(self, name):
+        self.name_ = name
 
     @set_doc(quippy.potential_module.Potential.calc.__doc__,
     """

--- a/quippy/quippy/potential.py
+++ b/quippy/quippy/potential.py
@@ -114,6 +114,10 @@ class Potential(ase.calculators.calculator.Calculator):
     def _get_name(self):
         return self.name_
 
+    @property
+    def name(self):
+        return self._get_name()
+
     @set_doc(quippy.potential_module.Potential.calc.__doc__,
     """
     Pythonic wrapper to `quippy.potential_module.Potential.calc()`

--- a/quippy/quippy/potential.py
+++ b/quippy/quippy/potential.py
@@ -100,7 +100,7 @@ class Potential(ase.calculators.calculator.Calculator):
         # from old
         if atoms is not None:
             atoms.calc = self
-        self.name = args_str
+        self.name_ = args_str
         if isinstance(calc_args, dict):
             calc_args = key_val_dict_to_str(calc_args)
         elif calc_args is None:
@@ -110,6 +110,9 @@ class Potential(ase.calculators.calculator.Calculator):
         # storage of non-standard results
         self.extra_results = {'config': {},
                               'atoms': {}}
+
+    def _get_name(self):
+        return self.name_
 
     @set_doc(quippy.potential_module.Potential.calc.__doc__,
     """

--- a/quippy/quippy/potential.py
+++ b/quippy/quippy/potential.py
@@ -111,6 +111,8 @@ class Potential(ase.calculators.calculator.Calculator):
         self.extra_results = {'config': {},
                               'atoms': {}}
 
+    # These two functions below are left in only for purposebackward compatibility, 
+    # we remember to clean it up if/when we decide ASE pre-3.23.0 isn't worth supporting.
     def _get_name(self):
         return self.name_
 


### PR DESCRIPTION
In the newest ase, the 'name' is a property of Calculator and will raise error when try to set name directly.