### PR TITLE
OpenMPI and OpenMP Makefiles for Archer2

### DIFF
--- a/arch/Makefile.archer2
+++ b/arch/Makefile.archer2
@@ -38,7 +38,6 @@ CPLUSPLUS = cc
 LINKER = ftn
 
 # OpenMP
-DEFINES += -D_OPENMP
 F95FLAGS += -fopenmp
 F77FLAGS += -fopenmp
 CFLAGS += -fopenmp

--- a/arch/Makefile.archer2
+++ b/arch/Makefile.archer2
@@ -7,6 +7,9 @@
 # HQ X
 # HQ X   Copyright 2021
 # HQ X
+# HQ X
+# HQ X   Edited by Vlad Carare and Lars Schaaf - working as of 07.04.2022
+# HQ X
 # HQ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 # ACRHER2 computer cluster, United Kingdom
@@ -15,10 +18,10 @@
 # - GNU compilers version 9, python and FFTW
 # - obtain these with the following on Archer2
 #
-# module restore PrgEnv-gnu
+# module switch PrgEnv-cray PrgEnv-gnu
+# module load PrgEnv-gnu
 # module load gcc/9.3.0
 # module load cray-fftw
-# module load cray-python
 
 
 

--- a/arch/Makefile.archer2
+++ b/arch/Makefile.archer2
@@ -47,3 +47,6 @@ LINKOPTS += -fopenmp
 QUIPPY_F90FLAGS += -fopenmp
 QUIPPY_CFLAGS += -fopenmp
 QUIPPY_LDFLAGS += -fopenmp
+
+# NOTE: Make sure to erase the defaults ("-llapack -lblas") when being prompted for "linking options for LAPACK and BLAS libraries". 
+#       On Archer2 the compiler wrappers (cc CC ftn) will link to the libsci library, which includes LAPACK and BLAS.

--- a/arch/Makefile.archer2_openmpi+openmp
+++ b/arch/Makefile.archer2_openmpi+openmp
@@ -38,7 +38,6 @@ CPLUSPLUS = cc
 LINKER = ftn
 
 # OpenMP
-DEFINES += -D_OPENMP
 F95FLAGS += -fopenmp
 F77FLAGS += -fopenmp
 CFLAGS += -fopenmp

--- a/arch/Makefile.archer2_openmpi+openmp
+++ b/arch/Makefile.archer2_openmpi+openmp
@@ -24,28 +24,10 @@
 # module load cray-fftw
 
 
-
 # declarations
 
-include arch/Makefile.linux_x86_64_gfortran
-
-# compiler settings, make sure this is GNU!
-F77 = ftn
-F90 = ftn
-F95 = ftn
-CC = cc
-CPLUSPLUS = cc
-LINKER = ftn
-
-# OpenMP
-F95FLAGS += -fopenmp
-F77FLAGS += -fopenmp
-CFLAGS += -fopenmp
-LINKOPTS += -fopenmp
-
-QUIPPY_F90FLAGS += -fopenmp
-QUIPPY_CFLAGS += -fopenmp
-QUIPPY_LDFLAGS += -fopenmp
+include arch/Makefile.archer2
+# OpenMP and compiler wrappers already defined in the archer2 makefile
 
 # MPI
 DEFINES += -D_MPI

--- a/arch/Makefile.archer2_openmpi+openmp
+++ b/arch/Makefile.archer2_openmpi+openmp
@@ -1,0 +1,52 @@
+# HQ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+# HQ X
+# H0 X   libAtoms+QUIP: atomistic simulation library
+# HQ X
+# HQ X   Portions of this code were written by
+# HQ X     Tamas K. Stenczel
+# HQ X
+# HQ X   Copyright 2021
+# HQ X
+# HQ X
+# HQ X   Edited by Vlad Carare and Lars Schaaf - working as of 07.04.2022
+# HQ X
+# HQ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+# ACRHER2 computer cluster, United Kingdom
+#
+# recommended modules to use with this:
+# - GNU compilers version 9, python and FFTW
+# - obtain these with the following on Archer2
+#
+# module switch PrgEnv-cray PrgEnv-gnu
+# module load PrgEnv-gnu
+# module load gcc/9.3.0
+# module load cray-fftw
+
+
+
+# declarations
+
+include arch/Makefile.linux_x86_64_gfortran
+
+# compiler settings, make sure this is GNU!
+F77 = ftn
+F90 = ftn
+F95 = ftn
+CC = cc
+CPLUSPLUS = cc
+LINKER = ftn
+
+# OpenMP
+DEFINES += -D_OPENMP
+F95FLAGS += -fopenmp
+F77FLAGS += -fopenmp
+CFLAGS += -fopenmp
+LINKOPTS += -fopenmp
+
+QUIPPY_F90FLAGS += -fopenmp
+QUIPPY_CFLAGS += -fopenmp
+QUIPPY_LDFLAGS += -fopenmp
+
+# MPI
+DEFINES += -D_MPI

--- a/arch/Makefile.archer2_openmpi+openmp
+++ b/arch/Makefile.archer2_openmpi+openmp
@@ -50,3 +50,6 @@ QUIPPY_LDFLAGS += -fopenmp
 
 # MPI
 DEFINES += -D_MPI
+
+# NOTE: Make sure to erase the defaults ("-llapack -lblas") when being prompted for "linking options for LAPACK and BLAS libraries". 
+#       On Archer2 the compiler wrappers (cc CC ftn) will link to the libsci library, which includes LAPACK and BLAS.


### PR DESCRIPTION
The old instructions for Archer2 needed updating. 

The pull also contains instructions for the new MPI implementation of GAP on Archer2. 

This was tested and worked as of today.