### PR TITLE
Feat: blocksize overflow check

### DIFF
--- a/src/libAtoms/ScaLAPACK.f95
+++ b/src/libAtoms/ScaLAPACK.f95
@@ -1485,6 +1485,8 @@ function get_lwork_pdgeqrf_i32o64(m, n, ia, ja, mb_a, nb_a, &
   integer :: iarow, iacol, iroff, icoff
   integer(idp) :: mp0, nq0, nb64
 
+  lwork = 0
+
 #ifdef SCALAPACK
   iroff = mod(ia-1, mb_a)
   icoff = mod(ja-1, nb_a)
@@ -1505,6 +1507,8 @@ function ScaLAPACK_get_lwork_pdgeqrf(this, m, n, mb_a, nb_a) result(lwork)
 
   integer, parameter :: ia = 1, ja = 1, rsrc_a = 0, csrc_a = 0
 
+  lwork = 0
+
 #ifdef SCALAPACK
   lwork = get_lwork_pdgeqrf(m, n, ia, ja, mb_a, nb_a, &
     this%my_proc_row, this%my_proc_col, rsrc_a, csrc_a, &
@@ -1515,6 +1519,8 @@ end function ScaLAPACK_get_lwork_pdgeqrf
 function ScaLAPACK_matrix_get_lwork_pdgeqrf(this) result(lwork)
   type(Matrix_ScaLAPACK_Info), intent(in) :: this
   integer(idp) :: lwork
+
+  lwork = 0
 
 #ifdef SCALAPACK
   lwork = get_lwork_pdgeqrf(this%ScaLAPACK_obj, this%N_R, this%N_C, this%NB_R, this%NB_C)
@@ -1535,6 +1541,8 @@ function get_lwork_pdormqr_i32o64(side, m, n, ia, ja, mb_a, nb_a, ic, jc, &
   integer :: lcm, lcmq
   integer :: iarow, iroffa, icoffa, iroffc, icoffc, icrow, iccol
   integer(idp) :: npa0, mpc0, nqc0, nr, nb64, lwork1, lwork2
+
+  lwork = 0
 
 #ifdef SCALAPACK
   iroffc = mod(ic-1, mb_c)
@@ -1574,6 +1582,8 @@ function ScaLAPACK_get_lwork_pdormqr(this, side, m, n, mb_a, nb_a, mb_c, nb_c) r
   integer, parameter :: ia = 1, ja = 1, rsrc_a = 0, csrc_a = 0
   integer, parameter :: ic = 1, jc = 1, rsrc_c = 0, csrc_c = 0
 
+  lwork = 0
+
 #ifdef SCALAPACK
   lwork = get_lwork_pdormqr(side, m, n, ia, ja, mb_a, nb_a, ic, jc, mb_c, nb_c, &
     this%my_proc_row, this%my_proc_col, rsrc_a, csrc_a, rsrc_c, csrc_c, &
@@ -1585,6 +1595,8 @@ function ScaLAPACK_matrix_get_lwork_pdormqr(A_info, C_info, side) result(lwork)
   type(Matrix_ScaLAPACK_Info), intent(in) :: A_info, C_info
   character :: side
   integer(idp) :: lwork
+
+  lwork = 0
 
 #ifdef SCALAPACK
   lwork = get_lwork_pdormqr(A_info%ScaLAPACK_obj, side, C_info%N_R, &

--- a/src/libAtoms/ScaLAPACK.f95
+++ b/src/libAtoms/ScaLAPACK.f95
@@ -1557,7 +1557,7 @@ function get_lwork_pdormqr_i32o64(side, m, n, ia, ja, mb_a, nb_a, ic, jc, &
     lcm = ilcm(nprow, npcol)
     lcmq = lcm / npcol
     nr = numroc(n+icoffc, nb_a, 0, 0, npcol)
-    nr = numroc(nr, nb_a, 0, 0, lcmq)
+    nr = numroc(int(nr, isp), nb_a, 0, 0, lcmq)
     nr = max(npa0 + nr, mpc0)
     lwork2 = (nqc0 + nr) * nb64
   end if

--- a/src/libAtoms/ScaLAPACK.f95
+++ b/src/libAtoms/ScaLAPACK.f95
@@ -1387,7 +1387,6 @@ subroutine ScaLAPACK_pdormqr_wrapper(A_info, A_data, C_info, C_data, tau, work)
   n = C_info%N_C
   k = size(tau)
 
-  call reallocate(tau, k) ! @fixme circular logic
   call reallocate(work, 1)
   call pdormqr('L', 'T', m, n, k, A_data, 1, 1, A_info%desc, &
     tau, C_data, 1, 1, C_info%desc, work, -1, info)

--- a/tests/test_gapfit.py
+++ b/tests/test_gapfit.py
@@ -145,7 +145,7 @@ class TestGAP_fit(quippytest.QuippyTestCase):
     @unittest.skipIf(os.environ.get('HAVE_SCALAPACK') != '1', 'ScaLAPACK support not enabled')
     def test_gap_fit_silicon_scalapack_big_blocksize(self):
         command_line = self.cl_template.safe_substitute(SPARSE_METHOD='sparse_method=FILE sparse_file=si_gap_fit_sparseX.inp')
-        command_line += ' mpi_blocksize_cols=44013'  # too large for 32bit integer
+        command_line += ' mpi_blocksize_cols=37838'  # too large for 32bit integer
         self.run_gap_fit(command_line, prefix='mpirun -np 2')
         with open(self.log_name) as f:
             self.assertTrue("too large for 32bit work array in ScaLAPACK" in f.read())

--- a/tests/test_gapfit.py
+++ b/tests/test_gapfit.py
@@ -142,5 +142,13 @@ class TestGAP_fit(quippytest.QuippyTestCase):
         self.check_gap_fit()
         self.check_latest_sparsex_file_hash()
 
+    @unittest.skipIf(os.environ.get('HAVE_SCALAPACK') != '1', 'ScaLAPACK support not enabled')
+    def test_gap_fit_silicon_scalapack_big_blocksize(self):
+        command_line = self.cl_template.safe_substitute(SPARSE_METHOD='sparse_method=FILE sparse_file=si_gap_fit_sparseX.inp')
+        command_line += ' mpi_blocksize_cols=44013'  # too large for 32bit integer
+        self.run_gap_fit(command_line, prefix='mpirun -np 2')
+        with open(self.log_name) as f:
+            self.assertTrue("too large for 32bit work array in ScaLAPACK" in f.read())
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Includes #437
Depends on https://github.com/libAtoms/GAP/pull/40

`mpi_blocksize` setting and checking is now done early. If `lwork` of `pdgeqrf` or `pdormqr` will overflow, this check fails early.