### PR TITLE
Feat: decouple blocksizes

### DIFF
--- a/tests/test_gapfit.py
+++ b/tests/test_gapfit.py
@@ -135,7 +135,7 @@ class TestGAP_fit(quippytest.QuippyTestCase):
     @unittest.skipIf(os.environ.get('HAVE_SCALAPACK') != '1', 'ScaLAPACK support not enabled')
     def test_gap_fit_silicon_scalapack(self):
         command_line = self.cl_template.safe_substitute(SPARSE_METHOD='sparse_method=FILE sparse_file=si_gap_fit_sparseX.inp')
-        command_line += ' mpi_blocksize=101'  # not a divisor of n_sparse
+        command_line += ' mpi_blocksize_rows=101'  # not a divisor of nrows
         self.run_gap_fit(command_line, prefix='mpirun -np 2')
         with open(self.log_name) as f:
             self.assertTrue("Using ScaLAPACK to solve QR" in f.read())


### PR DESCRIPTION
Cheat `pdtrtrs` to think blocksizes of A are identical asserting that there is only a single process column. Change `mpi_blocksize` to `mpi_blocksize_rows` and `mpi_blocksize_cols`.

:warning: This is a breaking change wrt. `mpi_blocksize`. Should not be much of a problem as it's an optional argument, only relevant for people who have tried out MPI and set it manually.

Depends on https://github.com/libAtoms/GAP/pull/42