### PR TITLE
Fix: Build wheels only on public, not PR

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -3,9 +3,6 @@ on:
     branches: [ public ]
     tags:
        - v*
-  pull_request:
-    branches: [ public ]
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
Don't run wheels builds on PRs (by default), they take 1h to finish.

If checking wheels before merge to public is much wanted, create a dev branch as a target for PRs.