### PR TITLE
Increase verbosity of "Potential_initialise using default init_args" warning

### DIFF
--- a/src/Potentials/AdjustablePotential.f95
+++ b/src/Potentials/AdjustablePotential.f95
@@ -1255,7 +1255,7 @@ contains
     integer, intent(in) :: atom1,atom2,shift(3)
 
     if (atom1 == atom2) then
-       call print_warning('Adjustable_Potential_Add_Exclusion: Atom1 = Atom2')
+       call print_message('WARNING', 'Adjustable_Potential_Add_Exclusion: Atom1 = Atom2')
        return
     end if
 

--- a/src/Potentials/AdjustablePotential.f95
+++ b/src/Potentials/AdjustablePotential.f95
@@ -65,7 +65,7 @@
 
 
 module AdjustablePotential_module
-  use system_module, only : dp, print, inoutput, PRINT_VERBOSE, PRINT_NERD, line, optional_default, mainlog, value, system_abort, reallocate, print_warning, operator(//), mpi_id, abort_on_mpi_error
+  use system_module, only : dp, print, inoutput, PRINT_VERBOSE, PRINT_NERD, line, optional_default, mainlog, value, system_abort, reallocate, print_message, operator(//), mpi_id, abort_on_mpi_error
   use linearalgebra_module
   use table_module
   use sparse_module

--- a/src/Potentials/IP.f95
+++ b/src/Potentials/IP.f95
@@ -127,7 +127,7 @@ module IP_module
 
 ! use system_module, only : dp
 use error_module
-use system_module, only : dp, inoutput, initialise, INPUT, print, print_warning, PRINT_VERBOSE, PRINT_ALWAYS, system_timer
+use system_module, only : dp, inoutput, initialise, INPUT, print, print_message, PRINT_VERBOSE, PRINT_ALWAYS, system_timer
 use units_module
 use mpi_context_module
 use extendable_str_module

--- a/src/Potentials/IP.f95
+++ b/src/Potentials/IP.f95
@@ -852,12 +852,12 @@ subroutine IP_Calc(this, at, energy, local_e, f, virial, local_virial, args_str,
           if (n_groups * pgroup_size == this%mpi_glob%n_procs) then
              do_auto_pgroups = .false.
           else
-             call print_warning("Invalid parallel group size specified: " // pgroup_size)
-             call print_warning("Falling back to automatic selection")
+             call print_message('WARNING', "Invalid parallel group size specified: " // pgroup_size)
+             call print_message('WARNING', "Falling back to automatic selection")
           endif
        else
-          call print_warning("Invalid parallel group size specified: " // pgroup_size)
-          call print_warning("Falling back to automatic selection")
+          call print_message('WARNING', "Invalid parallel group size specified: " // pgroup_size)
+          call print_message('WARNING', "Falling back to automatic selection")
        endif
     endif
     if (do_auto_pgroups) then

--- a/src/Potentials/Multipoles.f95
+++ b/src/Potentials/Multipoles.f95
@@ -34,7 +34,7 @@
 module Multipoles_module
 
 use error_module
-!use system_module, only : dp, print, inoutput, optional_default, system_timer, operator(//), print_warning
+!use system_module, only : dp, print, inoutput, optional_default, system_timer, operator(//), print_message
 use system_module
 use cinoutput_module
 use units_module

--- a/src/Potentials/Potential.f95
+++ b/src/Potentials/Potential.f95
@@ -531,8 +531,7 @@ recursive subroutine potential_initialise(this, args_str, pot1, pot2, param_str,
      tag_start = index(param_str, '<')
      tag_end = index(param_str, '>')
      xml_label = param_str(tag_start+1:tag_end-1)
-     call print_warning('Potential_initialise using default init_args "Potential xml_label='//trim(xml_label)//'"', &
-                        'INFO', PRINT_VERBOSE)
+     call print_message('INFO', 'Potential_initialise using default init_args "Potential xml_label='//trim(xml_label)//'"', PRINT_VERBOSE)
      my_args_str = 'Potential xml_label='//xml_label
   end if
 
@@ -847,7 +846,7 @@ recursive subroutine potential_initialise(this, args_str, pot1, pot2, param_str,
        ! if at%cutoff_skin is non-zero, as the full rebuild will only be done when atoms have moved sufficiently
        if (at%cutoff < cutoff(this)) then
           if (printed_cutoff_warning) call verbosity_push_decrement()
-          call print_warning('Potential_calc: cutoff of Atoms object ('//at%cutoff//') < Potential cutoff ('//cutoff(this)//') - increasing it now')
+          call print_message('WARNING', 'Potential_calc: cutoff of Atoms object ('//at%cutoff//') < Potential cutoff ('//cutoff(this)//') - increasing it now')
           if (printed_cutoff_warning) call verbosity_pop()
           printed_cutoff_warning = .true.
           call set_cutoff(at, cutoff(this))
@@ -1170,7 +1169,7 @@ recursive subroutine potential_initialise(this, args_str, pot1, pot2, param_str,
        if (at%cutoff < cutoff(this)) then
           ! print warning unless cutoff was 0.0 or -1, these are defaults for "no cutoff", so probably no warning needed
           if (at%cutoff /= 0.0_dp .and. at%cutoff /= -1.0_dp) then
-             call print_warning('Potential_calc: cutoff of Atoms object ('//at%cutoff//') < Potential cutoff ('//cutoff(this)//') - increasing it now')
+             call print_message('WARNING', 'Potential_calc: cutoff of Atoms object ('//at%cutoff//') < Potential cutoff ('//cutoff(this)//') - increasing it now')
           end if
           call set_cutoff(at, cutoff(this))
        end if
@@ -1207,7 +1206,7 @@ recursive subroutine potential_initialise(this, args_str, pot1, pot2, param_str,
        & (am%external_pressure(3,1) .fne. 0.0_dp) .or. &
        & (am%external_pressure(3,2) .fne. 0.0_dp) ) then
           if(trim(use_method) /= 'fire') then
-             call print_warning('Anisotrpic pressure is being used. Switching to fire_minim.')
+             call print_message('WARNING', 'Anisotrpic pressure is being used. Switching to fire_minim.')
              use_method = 'fire'
           endif
        endif
@@ -1295,7 +1294,7 @@ recursive subroutine potential_initialise(this, args_str, pot1, pot2, param_str,
 
     integer :: d, i, k, n, alpha
 
-    call print_warning("TLV: potential_test_local_virial: your cell has to be big enough so no multiple images are used for any atom.")
+    call print_message('WARNING', "TLV: potential_test_local_virial: your cell has to be big enough so no multiple images are used for any atom.")
 
     if(at%cutoff < cutoff(this)) call set_cutoff(at,cutoff(this))
 

--- a/src/Potentials/Potential.f95
+++ b/src/Potentials/Potential.f95
@@ -531,7 +531,8 @@ recursive subroutine potential_initialise(this, args_str, pot1, pot2, param_str,
      tag_start = index(param_str, '<')
      tag_end = index(param_str, '>')
      xml_label = param_str(tag_start+1:tag_end-1)
-     call print_warning('Potential_initialise using default init_args "Potential xml_label='//trim(xml_label)//'"')
+     call print_warning('Potential_initialise using default init_args "Potential xml_label='//trim(xml_label)//'"', &
+                        'INFO', PRINT_VERBOSE)
      my_args_str = 'Potential xml_label='//xml_label
   end if
 

--- a/src/Potentials/Potential.f95
+++ b/src/Potentials/Potential.f95
@@ -119,7 +119,7 @@ module Potential_module
 
   use error_module
   use system_module, only : dp, inoutput, print, PRINT_ALWAYS, PRINT_NORMAL, PRINT_VERBOSE, PRINT_NERD, initialise, finalise, INPUT, &
-   optional_default, current_verbosity, mainlog, round, verbosity_push_decrement, verbosity_push, verbosity_pop, print_warning, system_timer, system_abort, operator(//)
+   optional_default, current_verbosity, mainlog, round, verbosity_push_decrement, verbosity_push, verbosity_pop, print_message, system_timer, system_abort, operator(//)
   use units_module, only : EV_A3_IN_GPA
   use periodictable_module, only :  ElementCovRad, ElementMass
   use extendable_str_module, only : extendable_str, initialise, read, string, finalise

--- a/src/Potentials/Potential_Precon_Minim.f95
+++ b/src/Potentials/Potential_Precon_Minim.f95
@@ -545,7 +545,7 @@ module Potential_Precon_Minim_module
        & (am%external_pressure(3,1) .fne. 0.0_dp) .or. &
        & (am%external_pressure(3,2) .fne. 0.0_dp) ) then
           if(trim(use_method) /= 'fire') then
-             call print_warning('Anisotrpic pressure is being used. Switching to fire_minim.')
+             call print_message('WARNING', 'Anisotrpic pressure is being used. Switching to fire_minim.')
              use_method = 'fire'
           endif
        endif
@@ -777,7 +777,7 @@ module Potential_Precon_Minim_module
        & (am%external_pressure(3,1) .fne. 0.0_dp) .or. &
        & (am%external_pressure(3,2) .fne. 0.0_dp) ) then
           if(trim(use_method) /= 'fire') then
-             call print_warning('Anisotrpic pressure is being used. Switching to fire_minim.')
+             call print_message('WARNING', 'Anisotrpic pressure is being used. Switching to fire_minim.')
              use_method = 'fire'
           endif
        endif
@@ -1001,7 +1001,7 @@ module Potential_Precon_Minim_module
 !       & (am(I)%external_pressure(3,1) .fne. 0.0_dp) .or. &
 !       & (am(I)%external_pressure(3,2) .fne. 0.0_dp) ) then
 !          if(trim(use_method) /= 'fire') then
-!             call print_warning('Anisotrpic pressure is being used. Switching to fire_minim.')
+!             call print_message('WARNING', 'Anisotrpic pressure is being used. Switching to fire_minim.')
 !             use_method = 'fire'
 !          endif
 !       endif

--- a/src/Potentials/Potential_Precon_Minim.f95
+++ b/src/Potentials/Potential_Precon_Minim.f95
@@ -6,7 +6,7 @@ module Potential_Precon_Minim_module
   use Potential_Module, only : Potential, potential_minimise, energy_func, gradient_func, cutoff, max_rij_change, calc, print_hook, constrain_virial, fix_atoms_deform_grad, pack_pos_dg, unpack_pos_dg, prep_atoms_deform_grad
   use error_module
   use system_module, only : dp, inoutput, print, PRINT_ALWAYS, PRINT_NORMAL, PRINT_VERBOSE, PRINT_NERD, initialise, finalise, INPUT, &
-   optional_default, current_verbosity, mainlog, round, verbosity_push_decrement, verbosity_push,verbosity_push_increment, verbosity_pop, print_warning, system_timer, system_abort, operator(//)
+   optional_default, current_verbosity, mainlog, round, verbosity_push_decrement, verbosity_push,verbosity_push_increment, verbosity_pop, print_message, system_timer, system_abort, operator(//)
   use units_module, only : EV_A3_IN_GPA
   use periodictable_module, only :  ElementCovRad, ElementMass
   use extendable_str_module, only : extendable_str, initialise, read, string, finalise

--- a/src/Utils/phonons.f95
+++ b/src/Utils/phonons.f95
@@ -322,7 +322,7 @@ contains
                r_ij = distance_min_image(at,i,j,shift=shift_ij)
                if( r_ij >= at_max_cutoff ) then
                   if( any(abs(fp0(:,j,:,i)) > PHONON_FORCE_TOLERANCE) .or. any(abs(fm0(:,j,:,i)) > PHONON_FORCE_TOLERANCE) ) then
-                     call print_warning( "Phonon_fine_calc: in the supercell there are non-zero forces on atoms outside of the minimum-image cutoff sphere. &
+                     call print_message('WARNING',  "Phonon_fine_calc: in the supercell there are non-zero forces on atoms outside of the minimum-image cutoff sphere. &
                      Phonons computed in the fine supercell may be inaccurate. This problem may be eliminated by increasing phonon_supercell. &
                      Atoms in supercell: "//i//" and"//j//" from "//r_ij//" A from each other, forces are: "//reshape(fp0(:,j,:,i),(/9/)) &
                      //" "//reshape(fm0(:,j,:,i),(/9/)) )
@@ -344,7 +344,7 @@ contains
 
 ! Printing out the force constant and atomic positions in the phonopy format:
       if_my_phonopy_force_const_mat: if (my_phonopy_force_const_mat) then
-         call print_warning("phonopy_force_const_mat: This program prints out the force constants and atoms in the way phonopy 1.12.4 expects them. It is not guaranteed to work with other versions and does only support a single atomic species at a time (no alloys).")
+         call print_message('WARNING', "phonopy_force_const_mat: This program prints out the force constants and atoms in the way phonopy 1.12.4 expects them. It is not guaranteed to work with other versions and does only support a single atomic species at a time (no alloys).")
          !species_array = at_in%species
 !         do i_species = 2,len(at_in%species)
 !            print *, at_in%species(:,1)

--- a/src/libAtoms/Barostat.f95
+++ b/src/libAtoms/Barostat.f95
@@ -472,7 +472,7 @@ contains
        F_tmp = lattice_p .mult. this%lattice0_inv
        F_tmp = 0.5_dp*(F_tmp + transpose(F_tmp))
        if (abs(deviation_from_identity(F_tmp) - this%F_tmp_norm) > 5.0e-2) then
-         call print_warning("barostat transformation projecting away rotations is very different from previous one.  Did the lattice change?")
+         call print_message('WARNING', "barostat transformation projecting away rotations is very different from previous one.  Did the lattice change?")
        endif
        this%F_tmp_norm = deviation_from_identity(F_tmp)
        lattice_p = F_tmp .mult. this%lattice0
@@ -520,7 +520,7 @@ contains
         F_tmp = lattice_p .mult. this%lattice0_inv
         F_tmp = 0.5_dp*(F_tmp + transpose(F_tmp))
         if (abs(deviation_from_identity(F_tmp) - this%F_tmp_norm) > 5.0e-2) then
-           call print_warning("barostat transformation projecting away rotations is very different from previous one.  Did the lattice change?")
+           call print_message('WARNING', "barostat transformation projecting away rotations is very different from previous one.  Did the lattice change?")
         endif
         this%F_tmp_norm = deviation_from_identity(F_tmp)
         lattice_p = F_tmp .mult. this%lattice0

--- a/src/libAtoms/CInOutput.f95
+++ b/src/libAtoms/CInOutput.f95
@@ -1076,8 +1076,8 @@ contains
 
      my_stat = fmd5sum(trim(filename)//C_NULL_CHAR,tmp_md5sum)
      if( my_stat /= 0 ) then
-        call print_warning("quip_md5sum: could not obtain md5 sum of "//trim(filename))
-        call print_warning("quip_md5sum: fmd5sum returned with code "//my_stat)
+        call print_message('WARNING', "quip_md5sum: could not obtain md5 sum of "//trim(filename))
+        call print_message('WARNING', "quip_md5sum: fmd5sum returned with code "//my_stat)
         md5sum = ""
      else
         md5sum = tmp_md5sum(1:32)

--- a/src/libAtoms/CInOutput.f95
+++ b/src/libAtoms/CInOutput.f95
@@ -39,7 +39,7 @@ module CInOutput_module
   use linearalgebra_module, only: print, operator(.mult.), operator(.fne.)
   use Extendable_str_module, only: Extendable_str, operator(//), string, concat, assignment(=)
   use System_module, only: dp, current_verbosity, optional_default, s2a, a2s, parse_string, print, &
-       PRINT_NORMAL, PRINT_VERBOSE, PRINT_ALWAYS, PRINT_NERD, INPUT, OUTPUT, INOUT, lower_case, print_warning
+       PRINT_NORMAL, PRINT_VERBOSE, PRINT_ALWAYS, PRINT_NERD, INPUT, OUTPUT, INOUT, lower_case, print_message
   use PeriodicTable_module, only: atomic_number_from_symbol, ElementName
   use Table_module, only: Table, allocate, append, TABLE_STRING_LENGTH
   use Dictionary_module, only: Dictionary, has_key, get_value, set_value, print, subset, swap, lookup_entry_i, &

--- a/src/libAtoms/DynamicalSystem.f95
+++ b/src/libAtoms/DynamicalSystem.f95
@@ -2576,7 +2576,7 @@ contains
 
      !Do nothing for i==j
      if (i==j .or. i == k .or. j == k) then
-        call print_warning('Constrain_bondanglecos: Tried to constrain bond angle cosine '//i//'--'//j//'--'//k)
+        call print_message('WARNING', 'Constrain_bondanglecos: Tried to constrain bond angle cosine '//i//'--'//j//'--'//k)
         return
      end if
 
@@ -2621,7 +2621,7 @@ contains
 
      !Do nothing for i==j
      if (i==j) then
-        call print_warning('Constrain_bondlength: Tried to constrain bond '//i//'--'//j)
+        call print_message('WARNING', 'Constrain_bondlength: Tried to constrain bond '//i//'--'//j)
         return
      end if
 
@@ -2672,7 +2672,7 @@ contains
 
      !Do nothing for i==j
      if (i==j) then
-        call print_warning('Constrain_bondlength_sq: Tried to constrain bond '//i//'--'//j)
+        call print_message('WARNING', 'Constrain_bondlength_sq: Tried to constrain bond '//i//'--'//j)
         return
      end if
 
@@ -2711,7 +2711,7 @@ contains
 
      !Do nothing for i==j
      if (i==j) then
-        call print_warning('Constrain_bondlength_dev_pow: Tried to constrain bond '//i//'--'//j)
+        call print_message('WARNING', 'Constrain_bondlength_dev_pow: Tried to constrain bond '//i//'--'//j)
         return
      end if
 
@@ -2766,7 +2766,7 @@ contains
 
      !Do nothing for i==j or i==k or j==k
      if (i==j.or.i==k.or.j==k) then
-        call print_warning('Constrain_bondlength_Diff: Tried to constrain bond '//i//'--'//j//'--'//k)
+        call print_message('WARNING', 'Constrain_bondlength_Diff: Tried to constrain bond '//i//'--'//j//'--'//k)
         return
      end if
 
@@ -3126,7 +3126,7 @@ contains
 
         !Give warning if they constraint is not being satisfied
         if (abs(this%constraint(new_constraint)%C) > CONSTRAINT_WARNING_TOLERANCE) &
-             call print_warning('ds_add_constraint: This constraint ('//new_constraint//') is not currently obeyed: C = '// &
+             call print_message('WARNING', 'ds_add_constraint: This constraint ('//new_constraint//') is not currently obeyed: C = '// &
              round(this%constraint(new_constraint)%C,5))
 
         call constraint_store_gradient(this%constraint(new_constraint))

--- a/src/libAtoms/Group.f95
+++ b/src/libAtoms/Group.f95
@@ -695,7 +695,7 @@ contains
         do i = 1, size(lookup)
            if (lookup(i) == ungrouped) then
               write(line,'(a,i0,a)')'Groups_Create_Lookup: Atom ',i,' is ungrouped'
-              call print_warning(line)
+              call print_message('WARNING', line)
               ok = .false.
            end if
         end do

--- a/src/libAtoms/Structures.f95
+++ b/src/libAtoms/Structures.f95
@@ -941,7 +941,7 @@ contains
 
     if(present(supercell_index_name)) then
        if( has_property(aa, trim(supercell_index_name)) ) then
-          call print_warning("supercell_index_name = "//trim(supercell_index_name)//" but it is already present in atoms object, it will be overwritten.")
+          call print_message('WARNING', "supercell_index_name = "//trim(supercell_index_name)//" but it is already present in atoms object, it will be overwritten.")
        endif
        call add_property(aa, trim(supercell_index_name), 0, n_cols=3, ptr2=supercell_index, error=error, overwrite=.true.)
        PASS_ERROR(error)

--- a/src/libAtoms/System.f95
+++ b/src/libAtoms/System.f95
@@ -379,7 +379,7 @@ private
   public :: system_abort
   public :: verbosity_push_decrement
   public :: verbosity_pop
-  public :: print_warning
+  public :: print_message
   public :: pad
   public :: get_quippy_running
   public :: system_timer
@@ -776,7 +776,7 @@ contains
     else
        if (present(precision)) then
           if (precision > 99) then
-             call print_warning('Inoutput_Print_Real: Precision too high. Capping to 99.')
+             call print_message('WARNING', 'Inoutput_Print_Real: Precision too high. Capping to 99.')
              write(myformat,'(a)')'(f0.99)'
           else
              write(myformat,'(a,i0,a)')'(f0.',precision,')'
@@ -2419,15 +2419,13 @@ contains
   end subroutine system_finalise
 
   !% Print a warning message to log
-  subroutine print_warning(message, message_type, verbosity)
+  subroutine print_message(message_type, message, verbosity)
+    character(*), intent(in) :: message_type
     character(*), intent(in) :: message
-    character(*), intent(in), optional :: message_type ! default 'WARNING'
     integer, intent(in), optional :: verbosity ! default passed to print()
-    character(100) :: my_message_type
     !write (0,*) 'WARNING: '//message
-    my_message_type = optional_default('WARNING', message_type)
-    call print(my_message_type // ': ' // message, verbosity=verbosity)
-  end subroutine print_warning
+    call print(message_type // ': ' // message, verbosity=verbosity)
+  end subroutine print_message
 
   !% Take the values from 'date_and_time' and make a nice string
   function date_and_time_string(values)
@@ -2533,7 +2531,7 @@ contains
 !$  call print('libAtoms::Hello World: OpenMP parallelisation with '//OMP_get_num_threads()//' threads')
 !$  call get_env_var('OMP_STACKSIZE',omp_stacksize)
 !$  if(len_trim(omp_stacksize) == 0) then
-!$     call print_warning('libAtoms::Hello World: environment variable OMP_STACKSIZE not set explicitly. The default value - system and compiler dependent - may be too small for some applications.')
+!$     call print_message('WARNING', 'libAtoms::Hello World: environment variable OMP_STACKSIZE not set explicitly. The default value - system and compiler dependent - may be too small for some applications.')
 !$  else
 !$     call print('libAtoms::Hello World: OMP_STACKSIZE='//trim(omp_stacksize))
 !$  endif
@@ -2785,7 +2783,7 @@ contains
         ! Start a new timer
         stack_pos = stack_pos + 1
         if (stack_pos > TIMER_STACK) then
-           call print_warning('System_Timer: stack overflow, name ' // trim(name))
+           call print_message('WARNING', 'System_Timer: stack overflow, name ' // trim(name))
            return
         end if
 

--- a/src/libAtoms/System.f95
+++ b/src/libAtoms/System.f95
@@ -380,6 +380,7 @@ private
   public :: verbosity_push_decrement
   public :: verbosity_pop
   public :: print_message
+  public :: print_warning
   public :: pad
   public :: get_quippy_running
   public :: system_timer

--- a/src/libAtoms/System.f95
+++ b/src/libAtoms/System.f95
@@ -2419,10 +2419,14 @@ contains
   end subroutine system_finalise
 
   !% Print a warning message to log
-  subroutine print_warning(message)
+  subroutine print_warning(message, message_type, verbosity)
     character(*), intent(in) :: message
+    character(*), intent(in), optional :: message_type ! default 'WARNING'
+    integer, intent(in), optional :: verbosity ! default passed to print()
+    character(100) :: my_message_type
     !write (0,*) 'WARNING: '//message
-    call print('WARNING: '//message)
+    my_message_type = optional_default('WARNING', message_type)
+    call print(my_message_type // ': ' // message, verbosity=verbosity)
   end subroutine print_warning
 
   !% Take the values from 'date_and_time' and make a nice string

--- a/src/libAtoms/System.f95
+++ b/src/libAtoms/System.f95
@@ -2418,7 +2418,14 @@ contains
 #endif
   end subroutine system_finalise
 
-  !% Print a warning message to log
+  !% Backward compatible (replaced with print_message) routine to print a warning message to log
+  subroutine print_warning(message)
+    character(*), intent(in) :: message
+    !write (0,*) 'WARNING: '//message
+    call print_message('WARNING', message)
+  end subroutine print_warning
+
+  !% Print a message to log
   subroutine print_message(message_type, message, verbosity)
     character(*), intent(in) :: message_type
     character(*), intent(in) :: message

--- a/src/libAtoms/clusters.f95
+++ b/src/libAtoms/clusters.f95
@@ -3418,7 +3418,7 @@ type(inoutput), optional :: debugfile
       endif
 
       if (do_ignore_silica_residue) then
-         call print_warning('Overriding min_images_only since ignore_silica_residue=T')
+         call print_message('WARNING', 'Overriding min_images_only since ignore_silica_residue=T')
          do_min_images_only = .true. !lam81
       end if
       ! start with core


### PR DESCRIPTION
Add message_type and verbosity optional arguments to print_warning.  Use these argument to only print `'Potential_initialise using default init_args'` for VERBOSE and up

closes #490