### PR TITLE
GAP: Check A vs 32bit

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -51,7 +51,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y  gfortran libblas-dev liblapack-dev \
             openmpi-bin libopenmpi-dev netcdf-bin libnetcdf-dev libhdf5-serial-dev \
-            python-numpy
+            python3-numpy
 
           if [[ "$HAVE_SCALAPACK" == 1 ]]; then
             sudo apt-get install -y libscalapack-openmpi-dev

--- a/quippy/KIND_MAP
+++ b/quippy/KIND_MAP
@@ -10,6 +10,7 @@
  'complex' : {'8':   'complex_double',
               'dp':  'complex_double'},
  'integer' : {'':       'int',
+             'isp':     'int',
              '8':      'long_long',
              'idp':     'long_long',
              'c_intptr_t': 'long_long',

--- a/src/libAtoms/System.f95
+++ b/src/libAtoms/System.f95
@@ -1934,7 +1934,7 @@ contains
   end function string_cat_logical_array
 
   elemental function int_format_length_isp(i) result(len)
-    integer, intent(in)::i
+    integer(isp), intent(in)::i
     integer::len
     len = max(1,(-sign(1, i)+1)/2 + ceiling(log10(abs(real(i,dp))+0.01_dp)))
   end function int_format_length_isp
@@ -1947,7 +1947,7 @@ contains
 
   function string_cat_isp(string, int) result(res)
     character(*),      intent(in)  :: string
-    integer,           intent(in)  :: int
+    integer(isp),           intent(in)  :: int
     ! below we work out the exact length of the resultant string
     character(len(string)+int_format_length(int)) :: res
 

--- a/src/libAtoms/System.f95
+++ b/src/libAtoms/System.f95
@@ -67,7 +67,7 @@ private
 
   logical, public :: system_use_fortran_random = .false.
 
-  public :: isp, idp, dp, qp
+  public :: isp, idp, iwp, dp, qp
 
   character, public :: quip_new_line
 

--- a/src/libAtoms/kind_module.f95
+++ b/src/libAtoms/kind_module.f95
@@ -4,6 +4,7 @@ module kind_module
 
   integer, parameter, public :: isp = selected_int_kind(9)
   integer, parameter, public :: idp = selected_int_kind(18)
+  integer, parameter, public :: iwp = kind(isp)
 
 #ifdef QUAD_PRECISION
   integer, parameter, public :: dp = 16


### PR DESCRIPTION
Related to https://github.com/libAtoms/GAP/pull/66

Checks the size of the local part of matrix A against the 32bit integer limit early and aborts with a message how many MPI processes should at least be used to prevent this from happening.

This also includes counting the sparse points in a sparse or sparse index file early, and either aborting if it does not match the given number, or setting the internal variable to the count if it no number was given. The MPI features and memory estimate profit from this.

Concerns #494