### PR TITLE
Fix Docker: LAMMPS, Rust

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -238,7 +238,7 @@ ENV LAMMPS_PATH /opt/lammps
 ENV PATH ${LAMMPS_PATH}/src/:${PATH}
 
 # Build LAMMPS from github - faster and more reliable than from the website
-RUN git clone --branch stable --depth 1 https://github.com/lammps/lammps.git .
+RUN git clone --branch stable_29Sep2021_update3 --depth 1 https://github.com/lammps/lammps.git .
 
 # Build `shlib` objects first so they have `-fPIC` then symlink the directory
 # so they can be reused to build the binaries halving the compilation time.
@@ -260,8 +260,9 @@ RUN cd src \
 #####################################
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rust.sh
-RUN chmod u+r rust.sh
+RUN chmod u+rx rust.sh
 RUN ./rust.sh -y
+ENV PATH /root/.cargo/bin:$PATH
 
 RUN pip install git+https://github.com/Luthaf/rascaline.git
 


### PR DESCRIPTION
Package electrode was added in June 2022. It's activated by `yes-all` but only partly deactivated by `no-lib` due to preceding spaces in the include line. This hotfix pins the version to the latest stable tag before the change.

Also, `rust.sh` was not executable and `cargo` missing from `PATH`.