### PR TITLE
re-add md and vasp_driver to executables in wheel

### DIFF
--- a/.github/workflows/prepare-wheel-build.sh
+++ b/.github/workflows/prepare-wheel-build.sh
@@ -43,7 +43,9 @@ fi
 cp ${BUILDDIR}/../../README.md ${BUILDDIR}
 cp ${BUILDDIR}/../../quippy/setup.py ${BUILDDIR}
 
-# include `quip` and `gap_fit` command line tools and `libquip.a`
+# include desired command line tools and `libquip.a`
 cp ${BUILDDIR}/quip ${BUILDDIR}/quippy
 cp ${BUILDDIR}/gap_fit ${BUILDDIR}/quippy/
+cp ${BUILDDIR}/md ${BUILDDIR}/quippy/
+cp ${BUILDDIR}/vasp_driver ${BUILDDIR}/quippy/
 cp ${BUILDDIR}/libquip.a ${BUILDDIR}/quippy/


### PR DESCRIPTION
Copy all executables to BUILDDIR when building wheel.

closes #539 