### PR TITLE
Fix: GHA wheels MacOS

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -3,7 +3,6 @@ on:
     branches: [ public ]
     tags:
        - v*
-  pull_request:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -3,6 +3,7 @@ on:
     branches: [ public ]
     tags:
        - v*
+  pull_request:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -21,7 +22,8 @@ jobs:
           submodules: 'recursive'
       
       - uses: actions/setup-python@v4
-
+        with:
+          python-version: '3.x'
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.9.0
      


### PR DESCRIPTION
Set python version to `3.x` instead of the default `2.?`.