### PR TITLE
Programs: Fix install target

### DIFF
--- a/src/Programs/Makefile
+++ b/src/Programs/Makefile
@@ -96,5 +96,4 @@ install:
 	    echo "Copying $$f to ${QUIP_INSTALLDIR}/$${f}${QUIP_MPI_SUFFIX}" ; \
 	    cp $$f ${QUIP_INSTALLDIR}/$${f}${QUIP_MPI_SUFFIX} ; \
 	  done ;\
-
 	fi


### PR DESCRIPTION
Extra line empty line caused `syntax error: unexpected end of file`.