### PR TITLE
override STRING_LENGTH at compile time

### DIFF
--- a/src/libAtoms/Dictionary.f95
+++ b/src/libAtoms/Dictionary.f95
@@ -63,7 +63,11 @@ module dictionary_module
 
   public :: C_KEY_LEN, STRING_LENGTH, DICT_N_FIELDS
   integer, parameter :: C_KEY_LEN = 256
+#ifdef STRING_LENGTH_OVERRIDE
+  integer, parameter :: STRING_LENGTH = STRING_LENGTH_OVERRIDE      !% Maximum string length
+#else
   integer, parameter :: STRING_LENGTH = 30000      !% Maximum string length
+#endif
   integer, parameter :: DICT_N_FIELDS = 1000       !% Maximum number of fields during parsing
 
   public :: dictdata


### PR DESCRIPTION
Allow preprocessor symbol `STRING_LENGTH_OVERRIDE` to override `STRING_LENGTH` in `Dictionary.f95`

Useful for situations where the large strings lead to being allocated in static memory, which breaks thread safety.  Incompatible with very long comment or command lines, obviously, but sometimes that's a necessary compromise.  Would probably be better to just go to all allocatable strings, or to be more selective about which strings really need to be the very long `STRING_LENGTH`, but that's much more work.