### PR TITLE
Fix: obsolete entities for numpy 1.24

### DIFF
--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -158,8 +158,8 @@ class Test_Converter(quippytest.QuippyTestCase):
     def test_convert_add_arrays_unsupported_types(self):
         # setup of a separate atoms for this test
         at = self.at_base.copy()
-        at.arrays.update(dummy_obj_2d=np.zeros((3, 4), dtype=np.object),
-                         dummy_cplx_2d=np.zeros((3, 4), dtype=np.complex),
+        at.arrays.update(dummy_obj_2d=np.zeros((3, 4), dtype=object),
+                         dummy_cplx_2d=np.zeros((3, 4), dtype=complex),
                          dummy_void_2d=np.zeros((3, 4), dtype=np.void))
 
         # all should raise an error, the


### PR DESCRIPTION
Thanks to @thomas-rocke for pointing out this error.

Original error message for `numpy==1.24`:
```
AttributeError: module 'numpy' has no attribute 'object'.
`np.object` was a deprecated alias for the builtin `object`. To avoid this error in existing code, use `object` by itself. Doing this will not modify any behavior and is safe. 
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```
