### PR TITLE
[WIP] Fix memory leak when initializing GAP and vDW 

### DIFF
--- a/src/Potentials/IPModel_GAP.f95
+++ b/src/Potentials/IPModel_GAP.f95
@@ -934,6 +934,8 @@ subroutine IPModel_GAP_read_params_xml(this, param_str)
        characters_handler = IPModel_characters_handler)
      call close_xml_t(fxml)
 
+     call finalise(parse_cur_data)
+
      if(.not. parse_in_ip_done) &
      call  system_abort('IPModel_GAP_read_params_xml: could not initialise GAP potential. No GAP_params present?')
      this%initialised = .true.

--- a/src/Potentials/IPModel_vdW.f95
+++ b/src/Potentials/IPModel_vdW.f95
@@ -863,6 +863,8 @@ subroutine IPModel_vdW_read_params_xml(this, param_str)
        characters_handler = IPModel_characters_handler)
      call close_xml_t(fxml)
 
+     call finalise(parse_cur_data)
+
      if(.not. parse_in_ip_done) &
      call  system_abort('IPModel_vdW_read_params_xml: could not initialise vdW potential. No vdW_params present?')
      this%initialised = .true.


### PR DESCRIPTION
Finalise `parse_cur_data` after xml parsing in `IPModel_GAP`

Do same for `IPModel_vdW`

closes #605 