### PR TITLE
Omit manylinux2010 (EOL) from build-wheels

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -19,13 +19,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
-      
+
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.19.1
-     
+
       - name: Build wheels
         run: |
              if [ "$RUNNER_OS" == "Linux" ]; then
@@ -97,26 +97,20 @@ jobs:
                 ./bin/gitversion --hash-only > build/${QUIP_ARCH}/VERSION
                 echo "CIBW_ENVIRONMENT=$CIBW_ENVIRONMENT"
                 if [ "$RUNNER_OS" == "macOS" ]; then
-                   export CIBW_SKIP="cp27-* cp35-* cp36-* pp*"
-                   python -m cibuildwheel --output-dir wheelhouse --archs $ARCHS build/${QUIP_ARCH} 
-                 else
-                   for CIBW_MANYLINUX_X86_64_IMAGE in manylinux2010 manylinux2014; do
-                     if [ "$CIBW_MANYLINUX_X86_64_IMAGE" == "manylinux2010" ]; then
-                       export CIBW_SKIP="cp27-* cp35-* cp36-* cp310-* cp311-* pp* *musllinux*"
-                     else
-                       export CIBW_SKIP="cp27-* cp35-* cp36-* pp* *musllinux*"
-                     fi
-                     export CIBW_MANYLINUX_X86_64_IMAGE
-                     python -m cibuildwheel --output-dir wheelhouse --archs $ARCHS build/${QUIP_ARCH}
-                   done
-                 fi                
+                  export CIBW_SKIP="cp27-* cp35-* cp36-* pp*"
+                  python -m cibuildwheel --output-dir wheelhouse --archs $ARCHS build/${QUIP_ARCH}
+                else
+                  export CIBW_MANYLINUX_X86_64_IMAGE="manylinux2014"
+                  export CIBW_SKIP="cp27-* cp35-* cp36-* pp* *musllinux*"
+                  python -m cibuildwheel --output-dir wheelhouse --archs $ARCHS build/${QUIP_ARCH}
+                fi
              done
         env:
            CIBW_TEST_SKIP: "*-macosx_arm64"
            CIBW_BEFORE_ALL_MACOS: "brew install gfortran && brew unlink gfortran && brew link gfortran"
           #  CIBW_BEFORE_ALL_LINUX: "which yum && yum install -y gcc-gfortran || apk add gfortran"
            CIBW_BEFORE_BUILD: "bash .github/workflows/prepare-wheel-build.sh"
-           
+
       # Uncomment to get SSH access for testing
       - name: Setup tmate session
         if: failure()
@@ -126,7 +120,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
-          
+
       - name: Build source tarball
         if: startsWith(github.ref, 'refs/tags/')
         run: |


### PR DESCRIPTION
I think the wheels should default to manylinux2014.

The `openblas_support.py` file also needs some change. I'll probably push another commit for that.