### PR TITLE
Change rdkit-pypi to rdkit in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,8 +81,8 @@ RUN pip install --upgrade pip \
         jupyter \
         numpy \
         scipy \
-        scikit-learn\
-        scikit-build\
+        scikit-learn \
+        scikit-build \
         matplotlib \
         pyamg \
         imolecule \
@@ -91,7 +91,7 @@ RUN pip install --upgrade pip \
         nbsphinx \
         numpydoc \
         spglib \
-        rdkit-pypi \
+        rdkit \
         nglview \
         pandas \
         phonopy \


### PR DESCRIPTION
I have used `pip --dry-run` to make sure the packages exist and they can be installed.