### PR TITLE
MAINT: Fix return type errors from macros

### DIFF
--- a/src/libAtoms/libatoms.h
+++ b/src/libAtoms/libatoms.h
@@ -128,6 +128,11 @@
 #define PASS_ERROR if (error != NULL && *error != ERROR_NONE) { error_h_line = __LINE__; c_push_error_(__FILE__, &error_h_line, error, strlen(__FILE__)); return; }
 #define CLEAR_ERROR c_error_clear_stack_();
 
+#define RAISE_ERROR_INT(info, ...) sprintf(error_h_info, info, ## __VA_ARGS__ ); error_h_line = __LINE__; error_h_kind = ERROR_UNSPECIFIED; c_push_error_with_info_(error_h_info, __FILE__, &error_h_line, &error_h_kind, strlen(error_h_info), strlen(__FILE__)); if (error != NULL) { *error = error_h_kind; return -1; } else c_error_abort_(error)
+#define RAISE_ERROR_WITH_KIND_INT(kind, info, ...) sprintf(error_h_info, info, ## __VA_ARGS__ ); error_h_line = __LINE__; error_h_kind = kind; c_push_error_with_info_(error_h_info, __FILE__, &error_h_line, &error_h_kind, strlen(error_h_info), strlen(__FILE__)); if (error != NULL) { *error = error_h_kind; return -1; } else c_error_abort_(error)
+#define PASS_ERROR_INT if (error != NULL && *error != ERROR_NONE) { error_h_line = __LINE__; c_push_error_(__FILE__, &error_h_line, error, strlen(__FILE__)); return -1; }
+#define RAISE_ERROR_WITH_KIND_CHAR(kind, info, ...) sprintf(error_h_info, info, ## __VA_ARGS__ ); error_h_line = __LINE__; error_h_kind = kind; c_push_error_with_info_(error_h_info, __FILE__, &error_h_line, &error_h_kind, strlen(error_h_info), strlen(__FILE__)); if (error != NULL) { *error = error_h_kind; return '\0'; } else c_error_abort_(error)
+
 extern void c_push_error_with_info_(char*, char*, int*, int*, size_t, size_t);
 extern void c_push_error_(char*, int*, int*, size_t);
 extern void c_error_abort_(int *);


### PR DESCRIPTION
Will raise an error with `-Wreturn-types` otherwise. Basically the preprocessor macros are used in functions without `void`, so `return;` is incorrect.

Closes #656.