### PR TITLE
Fix incorrect type in fgetc and fputc

### DIFF
--- a/src/libAtoms/cutil.c
+++ b/src/libAtoms/cutil.c
@@ -249,7 +249,7 @@ void fwrite_line_to_file_(char *filename, char *line, char *mode) {
 
 void fappend_file_to_file_(char *filename_to, char *filename_from) {
    FILE *fp_to, *fp_from;
-   char ch;
+   int ch;
 
    fp_to = fopen(filename_to, "a");
    fp_from = fopen(filename_from, "r");


### PR DESCRIPTION
User reported issue using QUIP with GAP on Isambard 3 which is a Nvidia Grace CPU system.  This is an Arm/aarch64 architecture where char is unsigned whilst on x86 is it signed.  On x86 there is no problem since int and char are both signed.  On Arm/aarch64 when using fgetc with a char to check for EOL, it will never find EOL since -1 is wrapped to 255.

It seems it should be int anyway looking at standard for fgetc https://en.cppreference.com/w/c/io/fgetc and fputc https://en.cppreference.com/w/c/io/fputc

This fix should work on both x86 and aarch64.

