### PR TITLE
Fix macOS wheel bundling by setting DYLD_LIBRARY_PATH for delocate

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -122,10 +122,9 @@ jobs:
             QUIP_LIB_PATH="${GITHUB_WORKSPACE}/builddir/src/libAtoms:${GITHUB_WORKSPACE}/builddir/src/fox:${GITHUB_WORKSPACE}/builddir/src/GAP:${GITHUB_WORKSPACE}/builddir/src/Potentials:${GITHUB_WORKSPACE}/builddir/src/Utils"
 
           # macOS: Custom repair command to bundle QUIP libraries into wheel
-          # Use delocate-wheel with explicit library paths to avoid duplicate detection
-          # First find the GCC library path, then run delocate with all library paths
+          # Find GCC lib path via brew, set DYLD_LIBRARY_PATH for delocate to find all libs
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
-            GCC_LIB=$(dirname $(find /opt/homebrew/opt/gcc /usr/local/opt/gcc -name "libgfortran.5.dylib" 2>/dev/null | head -1)) &&
+            GCC_LIB="$(brew --prefix gcc)/lib/gcc/current" &&
             DYLD_LIBRARY_PATH="${GCC_LIB}:${QUIP_LIB_PATH}"
             delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -109,22 +109,23 @@ jobs:
             meson compile -C builddir
 
           # Set environment variables for builds
-          # Linux: Set PKG_CONFIG_PATH to where openblas.pc is installed
+          # Linux: Set PKG_CONFIG_PATH and LD_LIBRARY_PATH for auditwheel to find QUIP libraries
           CIBW_ENVIRONMENT_LINUX: >
             PKG_CONFIG_PATH="/usr/lib64/pkgconfig:/usr/local/lib64/pkgconfig"
+            LD_LIBRARY_PATH="/project/builddir/src/libAtoms:/project/builddir/src/fox:/project/builddir/src/GAP:/project/builddir/src/Potentials:/project/builddir/src/Utils:$LD_LIBRARY_PATH"
 
-          # macOS: Add paths for openblas
+          # macOS: Add paths for openblas and QUIP libraries
+          # QUIP_LIB_PATH is used by the repair command to find QUIP shared libraries
           CIBW_ENVIRONMENT_MACOS: >
             PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
             PKG_CONFIG_PATH="/opt/homebrew/opt/openblas/lib/pkgconfig:/usr/local/opt/openblas/lib/pkgconfig"
+            QUIP_LIB_PATH="$GITHUB_WORKSPACE/builddir/src/libAtoms:$GITHUB_WORKSPACE/builddir/src/fox:$GITHUB_WORKSPACE/builddir/src/GAP:$GITHUB_WORKSPACE/builddir/src/Potentials:$GITHUB_WORKSPACE/builddir/src/Utils"
 
-          # macOS: Custom repair command to handle duplicate libgfortran libraries
-          # delocate has issues with multiple libgfortran.dylib paths from QUIP's multiple libraries
-          # Try repair with arch check, then without, then skip repair (copy wheel as-is)
+          # macOS: Custom repair command to bundle QUIP libraries into wheel
+          # Set DYLD_LIBRARY_PATH so delocate can find QUIP shared libraries
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
-            delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} ||
-            delocate-wheel -w {dest_dir} -v {wheel} ||
-            cp {wheel} {dest_dir}/
+            DYLD_LIBRARY_PATH="$QUIP_LIB_PATH:$DYLD_LIBRARY_PATH"
+            delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
 
           # Build with meson-python (already configured in pyproject.toml)
           CIBW_BUILD_FRONTEND: "build"

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -115,10 +115,12 @@ jobs:
             LD_LIBRARY_PATH="/project/builddir/src/libAtoms:/project/builddir/src/fox:/project/builddir/src/GAP:/project/builddir/src/Potentials:/project/builddir/src/Utils:$LD_LIBRARY_PATH"
 
           # macOS: Pass through GITHUB_WORKSPACE and set library paths
+          # Set MACOSX_DEPLOYMENT_TARGET to match the runner's Homebrew libraries
           CIBW_ENVIRONMENT_PASS_MACOS: "GITHUB_WORKSPACE"
           CIBW_ENVIRONMENT_MACOS: >
             PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
             PKG_CONFIG_PATH="/opt/homebrew/opt/openblas/lib/pkgconfig:/usr/local/opt/openblas/lib/pkgconfig"
+            MACOSX_DEPLOYMENT_TARGET="14.0"
             QUIP_LIB_PATH="${GITHUB_WORKSPACE}/builddir/src/libAtoms:${GITHUB_WORKSPACE}/builddir/src/fox:${GITHUB_WORKSPACE}/builddir/src/GAP:${GITHUB_WORKSPACE}/builddir/src/Potentials:${GITHUB_WORKSPACE}/builddir/src/Utils"
 
           # macOS: Custom repair command to bundle QUIP libraries into wheel

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -114,17 +114,17 @@ jobs:
             PKG_CONFIG_PATH="/usr/lib64/pkgconfig:/usr/local/lib64/pkgconfig"
             LD_LIBRARY_PATH="/project/builddir/src/libAtoms:/project/builddir/src/fox:/project/builddir/src/GAP:/project/builddir/src/Potentials:/project/builddir/src/Utils:$LD_LIBRARY_PATH"
 
-          # macOS: Add paths for openblas and QUIP libraries
-          # QUIP_LIB_PATH is used by the repair command to find QUIP shared libraries
+          # macOS: Pass through GITHUB_WORKSPACE and set library paths
+          CIBW_ENVIRONMENT_PASS_MACOS: "GITHUB_WORKSPACE"
           CIBW_ENVIRONMENT_MACOS: >
             PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
             PKG_CONFIG_PATH="/opt/homebrew/opt/openblas/lib/pkgconfig:/usr/local/opt/openblas/lib/pkgconfig"
-            QUIP_LIB_PATH="$GITHUB_WORKSPACE/builddir/src/libAtoms:$GITHUB_WORKSPACE/builddir/src/fox:$GITHUB_WORKSPACE/builddir/src/GAP:$GITHUB_WORKSPACE/builddir/src/Potentials:$GITHUB_WORKSPACE/builddir/src/Utils"
+            QUIP_LIB_PATH="${GITHUB_WORKSPACE}/builddir/src/libAtoms:${GITHUB_WORKSPACE}/builddir/src/fox:${GITHUB_WORKSPACE}/builddir/src/GAP:${GITHUB_WORKSPACE}/builddir/src/Potentials:${GITHUB_WORKSPACE}/builddir/src/Utils"
 
           # macOS: Custom repair command to bundle QUIP libraries into wheel
-          # Set DYLD_LIBRARY_PATH so delocate can find QUIP shared libraries
+          # DYLD_LIBRARY_PATH helps delocate find QUIP shared libraries
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
-            DYLD_LIBRARY_PATH="$QUIP_LIB_PATH:$DYLD_LIBRARY_PATH"
+            DYLD_LIBRARY_PATH="${QUIP_LIB_PATH}"
             delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
 
           # Build with meson-python (already configured in pyproject.toml)

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -122,9 +122,11 @@ jobs:
             QUIP_LIB_PATH="${GITHUB_WORKSPACE}/builddir/src/libAtoms:${GITHUB_WORKSPACE}/builddir/src/fox:${GITHUB_WORKSPACE}/builddir/src/GAP:${GITHUB_WORKSPACE}/builddir/src/Potentials:${GITHUB_WORKSPACE}/builddir/src/Utils"
 
           # macOS: Custom repair command to bundle QUIP libraries into wheel
-          # DYLD_LIBRARY_PATH helps delocate find QUIP shared libraries
+          # Use delocate-wheel with explicit library paths to avoid duplicate detection
+          # First find the GCC library path, then run delocate with all library paths
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
-            DYLD_LIBRARY_PATH="${QUIP_LIB_PATH}"
+            GCC_LIB=$(dirname $(find /opt/homebrew/opt/gcc /usr/local/opt/gcc -name "libgfortran.5.dylib" 2>/dev/null | head -1)) &&
+            DYLD_LIBRARY_PATH="${GCC_LIB}:${QUIP_LIB_PATH}"
             delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
 
           # Build with meson-python (already configured in pyproject.toml)

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -47,7 +47,7 @@ jobs:
           echo "Updated quippy/meson.build:"
           head -5 quippy/meson.build
 
-      - name: Determine architecture
+      - name: Determine architecture and deployment target
         id: arch
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
@@ -56,8 +56,10 @@ jobs:
             # macos-15-intel is x86_64, macos-14 is arm64
             if [[ "${{ matrix.os }}" == "macos-14" ]]; then
               echo "arch=arm64" >> $GITHUB_OUTPUT
+              echo "macos_target=14.0" >> $GITHUB_OUTPUT
             else
               echo "arch=x86_64" >> $GITHUB_OUTPUT
+              echo "macos_target=15.0" >> $GITHUB_OUTPUT
             fi
           fi
 
@@ -120,7 +122,7 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: >
             PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
             PKG_CONFIG_PATH="/opt/homebrew/opt/openblas/lib/pkgconfig:/usr/local/opt/openblas/lib/pkgconfig"
-            MACOSX_DEPLOYMENT_TARGET="14.0"
+            MACOSX_DEPLOYMENT_TARGET="${{ steps.arch.outputs.macos_target }}"
             QUIP_LIB_PATH="${GITHUB_WORKSPACE}/builddir/src/libAtoms:${GITHUB_WORKSPACE}/builddir/src/fox:${GITHUB_WORKSPACE}/builddir/src/GAP:${GITHUB_WORKSPACE}/builddir/src/Potentials:${GITHUB_WORKSPACE}/builddir/src/Utils"
 
           # macOS: Custom repair command to bundle QUIP libraries into wheel


### PR DESCRIPTION
## Summary

The v0.10.0 wheels are broken - they can't be imported because the QUIP shared libraries weren't bundled into the wheels.

**macOS issue:** `delocate-wheel` couldn't find the QUIP libraries because `DYLD_LIBRARY_PATH` wasn't set. The fallback (`cp {wheel} {dest_dir}/`) silently produced broken wheels.

**Linux issue:** `auditwheel` couldn't find the QUIP libraries because `LD_LIBRARY_PATH` wasn't set.

## Fix

**macOS:**
- Add `QUIP_LIB_PATH` environment variable pointing to QUIP library directories
- Set `DYLD_LIBRARY_PATH` in the repair command so delocate can find the libraries
- Remove the fallback that produced broken wheels (fail fast instead)

**Linux:**
- Add `LD_LIBRARY_PATH` with QUIP library paths so auditwheel can find them

## Test plan

- [ ] CI wheel builds pass on all platforms
- [ ] macOS wheel can be installed and `import quippy` works
- [ ] Linux wheel can be installed and `import quippy` works
- [ ] Tag v0.10.1 to release fixed wheels

🤖 Generated with [Claude Code](https://claude.com/claude-code)