### PR TITLE
Add NumPy 2.x support with conditional dependencies

### DIFF
--- a/quippy/pyproject.toml
+++ b/quippy/pyproject.toml
@@ -1,7 +1,10 @@
 [build-system]
 requires = [
     "meson-python>=0.13.0",
-    "numpy>=1.20",
+    # Use oldest-supported-numpy for Python <3.12 to ensure ABI compatibility with NumPy 1.x
+    # Use NumPy 2.0+ for Python >=3.12 where NumPy 2.x is the standard
+    "oldest-supported-numpy; python_version<'3.12'",
+    "numpy>=2.0; python_version>='3.12'",
     "meson>=1.1.0",
     "f90wrap>=0.3.0",
 ]
@@ -14,7 +17,10 @@ description = "ASE-compatible Python bindings for the QUIP and GAP codes"
 readme = {file = "README", content-type = "text/plain"}
 requires-python = ">=3.9"
 dependencies = [
-    "numpy>=1.20",
+    # Python <3.12 wheels are built against NumPy 1.x (via oldest-supported-numpy)
+    # Python >=3.12 wheels are built against NumPy 2.x
+    "numpy>=1.20,<2; python_version<'3.12'",
+    "numpy>=2.0; python_version>='3.12'",
     "ase>=3.17.0",
     "f90wrap>=0.3.0",
 ]

--- a/quippy/pyproject.toml
+++ b/quippy/pyproject.toml
@@ -1,10 +1,7 @@
 [build-system]
 requires = [
     "meson-python>=0.13.0",
-    # Use oldest-supported-numpy for Python <3.12 to ensure ABI compatibility with NumPy 1.x
-    # Use NumPy 2.0+ for Python >=3.12 where NumPy 2.x is the standard
-    "oldest-supported-numpy; python_version<'3.12'",
-    "numpy>=2.0; python_version>='3.12'",
+    "numpy>=1.20",
     "meson>=1.1.0",
     "f90wrap>=0.3.0",
 ]
@@ -17,10 +14,8 @@ description = "ASE-compatible Python bindings for the QUIP and GAP codes"
 readme = {file = "README", content-type = "text/plain"}
 requires-python = ">=3.9"
 dependencies = [
-    # Python <3.12 wheels are built against NumPy 1.x (via oldest-supported-numpy)
-    # Python >=3.12 wheels are built against NumPy 2.x
-    "numpy>=1.20,<2; python_version<'3.12'",
-    "numpy>=2.0; python_version>='3.12'",
+    # Wheels are built against NumPy 2.x and require it at runtime
+    "numpy>=2.0",
     "ase>=3.17.0",
     "f90wrap>=0.3.0",
 ]


### PR DESCRIPTION
## Summary

Updates the runtime dependency from `numpy>=1.20` to `numpy>=2.0`.

## Rationale

The current `numpy>=1.20` build dependency causes pip to install the latest NumPy (2.x) at build time. This means the published wheels are already built against NumPy 2.x and are **incompatible with NumPy 1.x at runtime** due to ABI changes.

However, the runtime dependency still says `numpy>=1.20`, which allows users to have NumPy 1.x installed. When they install quippy-ase from PyPI with NumPy 1.x, they get cryptic runtime errors instead of a clear dependency conflict.

This PR makes the runtime requirement explicit: `numpy>=2.0`. Users with NumPy 1.x will now get a clear error at install time:
```
ERROR: quippy-ase requires numpy>=2.0, but you have numpy 1.26.4
```

Users who need NumPy 1.x compatibility can still build quippy from source with their desired NumPy version.

Closes #699

## Test plan

- [x] All CI builds pass (no change to build process, just runtime metadata)
- [x] Verified wheels are built against NumPy 2.x (CI logs show "NumPy 2.0+ detected")

🤖 Generated with [Claude Code](https://claude.ai/code)