### PR TITLE
default md5.h to define function prototypes

### DIFF
--- a/src/libAtoms/md5.h
+++ b/src/libAtoms/md5.h
@@ -7,7 +7,7 @@
 The following makes PROTOTYPES default to 0 if it has not already  been defined with C compiler flags.
  */
 #ifndef PROTOTYPES
-#define PROTOTYPES 0
+#define PROTOTYPES 1
 #endif
 
 /* POINTER defines a generic pointer type */


### PR DESCRIPTION
modernize `md5.[ch]`

Axel Kohlmeyer is not wrong that defaulting to no function prototypes is very outdated