### PR TITLE
Add support for (transparently) reading binary sparseX files

### DIFF
--- a/src/libAtoms/cutil.c
+++ b/src/libAtoms/cutil.c
@@ -202,6 +202,14 @@ void fwrite_array_d_(int *size, double *v, char *filename) {
    fclose(fp);
 }
 
+void fwrite_array_d_bin_(int *size, double *v, char *filename) {
+   FILE *fp;
+   int i;
+   fp = fopen(filename, "w");
+   fwrite(v, *size, sizeof(double), fp);
+   fclose(fp);
+}
+
 void fread_array_d_(int *size, double *v, char *filename) {
    FILE *fp;
    int i;
@@ -219,7 +227,14 @@ void fread_array_i_(int *size, int *v, char *filename) {
 
    fp = fopen(filename, "r");
    for (i=0; i < *size; i++) {
-      fscanf(fp, "%i", v+i);
+      int n_read = fscanf(fp, "%lf", v+i);
+      if (i == 0 && n_read <= 0) {
+          // try binary
+          fclose(fp);
+          fp = fopen(filename, "r");
+          fread(v, *size, sizeof(double), fp);
+          break;
+      }
    }
    fclose(fp);
 }

--- a/src/libAtoms/cutil.c
+++ b/src/libAtoms/cutil.c
@@ -216,7 +216,14 @@ void fread_array_d_(int *size, double *v, char *filename) {
 
    fp = fopen(filename, "r");
    for (i=0; i < *size; i++) {
-      fscanf(fp, "%lf", v+i);
+      int n_read = fscanf(fp, "%lf", v+i);
+      if (i == 0 && n_read <= 0) {
+          // try binary
+          fclose(fp);
+          fp = fopen(filename, "r");
+          fread(v, *size, sizeof(double), fp);
+          break;
+      }
    }
    fclose(fp);
 }
@@ -227,14 +234,7 @@ void fread_array_i_(int *size, int *v, char *filename) {
 
    fp = fopen(filename, "r");
    for (i=0; i < *size; i++) {
-      int n_read = fscanf(fp, "%lf", v+i);
-      if (i == 0 && n_read <= 0) {
-          // try binary
-          fclose(fp);
-          fp = fopen(filename, "r");
-          fread(v, *size, sizeof(double), fp);
-          break;
-      }
+      fscanf(fp, "%i", v+i);
    }
    fclose(fp);
 }

--- a/src/libAtoms/xyz.c
+++ b/src/libAtoms/xyz.c
@@ -49,7 +49,7 @@
 
 #include "libatoms.h"
 
-#define LINESIZE 2048
+#define LINESIZE 20480
 #define MAX_ENTRY_COUNT 200
 #define MAX_FIELD_COUNT 200
 #define PROPERTY_STRING_LENGTH 10

--- a/src/libAtoms/xyz.c
+++ b/src/libAtoms/xyz.c
@@ -49,7 +49,7 @@
 
 #include "libatoms.h"
 
-#define LINESIZE 20480
+#define LINESIZE 10000
 #define MAX_ENTRY_COUNT 200
 #define MAX_FIELD_COUNT 200
 #define PROPERTY_STRING_LENGTH 10


### PR DESCRIPTION
Also extend default line length in xyz.c

Will need to go along with GAP submodule update

New fwrite_array_d_bin_ just there for completeness, would need to add stuff to use it to write binary files. Plan for now is to have a separate executable included in GAP to convert standard sparseX files from text to binary.