### PR TITLE
Include programs in meson build's installations

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -67,8 +67,10 @@ jobs:
 
       - name: Build QUIP libraries
         run: |
-          meson setup builddir
+          meson setup builddir --prefix=$GITHUB_WORKSPACE/quip-install
           meson compile -C builddir
+          meson install -C builddir
+          test -f $GITHUB_WORKSPACE/quip-install/bin/gap_fit
         env:
           PKG_CONFIG_PATH: ${{ runner.os == 'macOS' && '/opt/homebrew/opt/openblas/lib/pkgconfig:/usr/local/opt/openblas/lib/pkgconfig' || '' }}
 

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('quip','fortran','c',
-  version : '0.10.3',
+  version : '0.10.4',
   default_options : ['warning_level=3'],
   meson_version : '>=1.1'
   )

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('quip','fortran','c',
-  version : '0.1',
+  version : '0.10.3',
   default_options : ['warning_level=3'],
   meson_version : '>=1.1'
   )

--- a/quippy/meson.build
+++ b/quippy/meson.build
@@ -1,6 +1,6 @@
 # Version is updated by CI from git tags (see .github/workflows/build-wheels.yml)
 project('quippy', 'c', 'fortran',
-  version: '0.10.0',
+  version: '0.10.4',
   meson_version: '>=1.1.0',
   default_options: [
     'buildtype=release',

--- a/src/Programs/meson.build
+++ b/src/Programs/meson.build
@@ -53,6 +53,7 @@ foreach prog : standard_programs
     link_with: link_quip,
     dependencies: [blas_dep],
     override_options: ['b_lundef=false'],
+    install: true,
   )
 endforeach
 
@@ -61,12 +62,14 @@ executable('quip', 'quip.F90',
   link_with: link_quip,
   dependencies: [blas_dep, mpi_dep],
   override_options: ['b_lundef=false'],
+  install: true,
 )
 
 executable('gap_fit', '../GAP/gap_fit.F90',
   link_with: link_quip + [gap_fit_lib],
   dependencies: [blas_dep, mpi_dep],
   override_options: ['b_lundef=false'],
+  install: true,
 )
 
 # C program
@@ -74,4 +77,5 @@ executable('quip_wrapper_simple_example_C', 'quip_wrapper_simple_example_C.c',
   link_with: link_quip,
   dependencies: [blas_dep],
   override_options: ['b_lundef=false'],
+  install: true,
 )


### PR DESCRIPTION
Added `install: true` to programs, so `gap_fit` is installed by the `meson` build system as well in `<prefix>/bin/*`. The CI now runs install as well, and tests that the executable had been created there.

Also bumped the version to `0.10.4`, but I see this is not tied to the releases on github. Should I revert this @jameskermode?

For #722.